### PR TITLE
Add weekly email digests for specific topics

### DIFF
--- a/.github/workflows/send_weekly_digests.yml
+++ b/.github/workflows/send_weekly_digests.yml
@@ -1,0 +1,94 @@
+name: Send Weekly Topic Digests
+
+on:
+  schedule:
+    # Run weekly on Monday at 14:00 UTC (9:00am CDT / 8:00am CST)
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+    inputs:
+      week_id:
+        description: "Week ID to process (YYYY-WXX format, defaults to previous week)"
+        required: false
+      dry_run:
+        description: "Dry run mode (true/false)"
+        required: false
+        default: "false"
+
+jobs:
+  send-weekly-digests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "backend/.python-version"
+
+      - name: Install dependencies
+        run: |
+          cd backend
+          uv sync --locked
+
+      - name: Generate Weekly Reports
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          cd backend
+          ARGS=""
+          if [ "${{ github.event.inputs.week_id }}" != "" ]; then
+            ARGS="$ARGS --week-id ${{ github.event.inputs.week_id }}"
+          fi
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          
+          echo "Generating reports with args: $ARGS"
+          uv run python -m utils.process_weekly_reports $ARGS
+
+      - name: Queue Weekly Notifications
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          cd backend
+          ARGS=""
+          if [ "${{ github.event.inputs.week_id }}" != "" ]; then
+            ARGS="$ARGS --week-id ${{ github.event.inputs.week_id }}"
+          fi
+          
+          if [ "${{ github.event.inputs.dry_run }}" != "true" ]; then
+             echo "Queuing notifications..."
+             uv run python -m notifications.weekly_notification_queue $ARGS
+          else
+             echo "Dry run: Skipping notification queuing"
+          fi
+
+      - name: Send Weekly Digest Emails
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          NOTIFICATION_FROM_EMAIL: ${{ secrets.NOTIFICATION_FROM_EMAIL }}
+          FRONTEND_BASE_URL: ${{ secrets.FRONTEND_BASE_URL }}
+          UNSUBSCRIBE_SECRET_KEY: ${{ secrets.UNSUBSCRIBE_SECRET_KEY }}
+        run: |
+          cd backend
+          ARGS="--weekly-digest"
+          if [ "${{ github.event.inputs.week_id }}" != "" ]; then
+            ARGS="$ARGS --batch-id ${{ github.event.inputs.week_id }}"
+          fi
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          
+          echo "Sending emails with args: $ARGS"
+          uv run python -m notifications.process_notification_queue $ARGS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,10 +233,15 @@ frontend/src/
 
 **Notification System** (`notifications/`):
 
-- `rule_matcher.py` - Matches newsletters against user rules (topics, search terms, wards). All filters AND-ed, within categories OR-ed.
-- `email_sender.py` - Sends daily digests via Resend API with HTML/plain text templates
+- `rule_matcher.py` - Matches newsletters against user rules (topics, search terms, wards). All filters AND-ed, within categories OR-ed. **Ward filters only apply to daily digest notifications.**
+- `email_sender.py` - Sends daily and weekly digests via Resend API with HTML/plain text templates
 - `process_notification_queue.py` - Orchestrates digest sending, groups by user, updates queue status, records in history
+- `weekly_notification_queue.py` - Queues weekly topic report notifications (topic-based only, no ward filtering)
 - Integration: Email ingestion queues notifications when `ENABLE_NOTIFICATIONS=true`. Web scraping does NOT trigger notifications (intentional). Failures don't break ingestion.
+
+**Notification Types:**
+- **Daily Digest**: Real-time alerts when newsletters match user criteria (topics, keywords, wards). Supports ward filtering.
+- **Weekly Summary**: Citywide topic reports delivered every Monday. Always covers all wards - ward filters are not supported for weekly summaries.
 
 **Privacy Sanitization** (`email_parser.py:sanitize_content()`): Config-driven filtering using `backend/config/privacy_patterns.py` (URL patterns, text patterns, CSS selectors defined as Python constants). Pure function receives patterns as parameter for testability. Links with images unwrapped; text-only privacy links removed. See `backend/tests/test_sanitization*.py` for test coverage.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,11 @@ uv run python -m notifications.process_notification_queue --daily-digest
 # Send specific date's digest
 uv run python -m notifications.process_notification_queue --daily-digest --batch-id 2026-01-21
 
+# Weekly Reports
+uv run python -m utils.process_weekly_reports            # Generate reports
+uv run python -m notifications.weekly_notification_queue # Queue notifications
+uv run python -m notifications.process_notification_queue --weekly-digest # Send emails
+
 # Run all tests
 uv run python -m unittest discover -s tests
 
@@ -131,7 +136,8 @@ See `backend/docs/LOCAL_LLM_PROCESSING.md` for full guide.
 2. **Source Matching**: Email patterns matched against `email_source_mappings` table with wildcard support
 3. **Storage**: Raw newsletters stored in `newsletters` table (plain_text, raw_html, metadata)
 4. **LLM Processing**: Three separate Ollama calls per newsletter for topic extraction, summarization, and relevance scoring (see `llm_processor.py` for details)
-5. **Frontend**: Astro SSR queries Supabase for search/display
+5. **Weekly Synthesis**: Aggregated analysis of newsletters by topic using two-phase LLM process (extract facts → synthesize summary)
+6. **Frontend**: Astro SSR queries Supabase for search/display
 
 ### Backend Structure
 
@@ -207,7 +213,7 @@ frontend/src/
 
 **Core Tables:** `sources` (aldermen/officials), `email_source_mappings` (pattern matching), `newsletters` (content with full-text search)
 
-**Notification Tables:** `user_profiles`, `notification_rules`, `notification_queue`, `notification_history`
+**Notification Tables:** `user_profiles`, `notification_rules`, `notification_queue`, `notification_history`, `weekly_topic_reports`
 
 **Full schema and RLS policies:** See [backend/SCHEMA.md](backend/SCHEMA.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,9 @@ uv run python -m utils.process_weekly_reports            # Generate reports
 uv run python -m notifications.weekly_notification_queue # Queue notifications
 uv run python -m notifications.process_notification_queue --weekly-digest # Send emails
 
+# Test/iterate on weekly summary prompt (without full pipeline)
+uv run python -m utils.test_weekly_summary --sample                     # Test with sample data
+
 # Run all tests
 uv run python -m unittest discover -s tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,8 @@ uv run python -m notifications.process_notification_queue --daily-digest
 uv run python -m notifications.process_notification_queue --daily-digest --batch-id 2026-01-21
 
 # Weekly Reports
-uv run python -m utils.process_weekly_reports            # Generate reports
+uv run python -m utils.process_weekly_reports            # Generate reports (previous week)
+uv run python -m utils.process_weekly_reports --current-week  # Generate for current week (manual Sunday runs)
 uv run python -m notifications.weekly_notification_queue # Queue notifications
 uv run python -m notifications.process_notification_queue --weekly-digest # Send emails
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,9 @@ uv run python -m utils.test_weekly_summary --sample                     # Test w
 # Run all tests
 uv run python -m unittest discover -s tests
 
+# Run tests with performance timing
+uv run python utils/time_tests.py
+
 # Code quality checks (run before committing Python changes)
 uv run ruff check --fix
 uv run ruff format

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Searchable archive of newsletters from Chicago aldermen. Built for [Strong Towns
 - **Web Scraping**: MailChimp archive scraping for historical newsletters
 - **LLM Processing**: Topic extraction, summarization, relevance scoring
 - **Full-Text Search**: Search with filters (ward, topic, relevance score)
-- **User Notifications**: Daily digest emails for newsletters matching user-defined rules (topics, search phrases, wards)
+- **User Notifications**: Daily digest emails for newsletters matching user-defined rules, or weekly topic reports
 - **One-Click Unsubscribe**: Secure, JWT-based unsubscribe links in emails (RFC 8058 compliant)
 - **Privacy Protection**: Automatic removal of tracking links, unsubscribe URLs, and sensitive content
 - **Testing Suite**: Backend unit/integration tests, frontend unit tests
@@ -102,11 +102,24 @@ uv run python -m notifications.test_matcher --queue
 # Send daily digest (dry run)
 uv run python -m notifications.process_notification_queue --daily-digest --dry-run
 
-# Send today's digest
+# Send today's daily digest
 uv run python -m notifications.process_notification_queue --daily-digest
 
 # Send specific date's digest
 uv run python -m notifications.process_notification_queue --daily-digest --batch-id 2026-01-21
+```
+
+#### Weekly Reports
+
+```bash
+# Generate weekly reports for active topics
+uv run python -m utils.process_weekly_reports
+
+# Queue notifications for generated reports
+uv run python -m notifications.weekly_notification_queue
+
+# Send weekly digest emails
+uv run python -m notifications.process_notification_queue --weekly-digest
 ```
 
 #### Testing
@@ -167,13 +180,17 @@ Three separate Ollama queries per newsletter for topic extraction, summarization
 
 ## Notification System
 
-Users create alert rules to receive daily digest emails for matching newsletters. Rules support topic-based matching, search phrase matching, and ward filtering.
+The system supports two types of notifications:
 
-Email ingestion automatically queues matching notifications when `ENABLE_NOTIFICATIONS=true`. Daily digest sending is handled by `backend/notifications/process_notification_queue.py`.
+1.  **Daily Digest**: Immediate updates when newsletters match user rules (topics, search phrases, wards).
+2.  **Weekly Topic Report**: AI-synthesized summary of all activity for a subscribed topic over the past week.
+
+Users configure these preferences via the frontend. Email ingestion automatically queues daily notifications. Weekly reports are generated via a scheduled process.
 
 **Key files:**
 
 - `backend/notifications/rule_matcher.py` - Matching logic
+- `backend/processing/weekly_report_generator.py` - Weekly report LLM synthesis
 - `backend/notifications/email_sender.py` - Email delivery via Resend
 - `frontend/src/pages/preferences.astro` - User preference management
 - `frontend/src/pages/unsubscribe.astro` - One-click unsubscribe
@@ -188,7 +205,8 @@ Newsletter content is automatically sanitized to remove tracking links, unsubscr
 ## Deployment
 
 - **Email Ingestion**: Automated via GitHub Actions (see `.github/workflows/email_ingestion.yml`)
-- **Notification Sending**: Automated via GitHub Actions (see `.github/workflows/send_notifications.yml`)
+- **Daily Notifications**: Automated via GitHub Actions (see `.github/workflows/send_notifications.yml`)
+- **Weekly Reports**: Automated via GitHub Actions (see `.github/workflows/send_weekly_digests.yml`)
 - **LLM Processing**: Manual local execution with Ollama (see `backend/docs/LOCAL_LLM_PROCESSING.md`)
 - **Frontend**: Auto-deploy via Cloudflare Pages on push to main
 

--- a/backend/SCHEMA.md
+++ b/backend/SCHEMA.md
@@ -179,13 +179,14 @@ User-defined notification rules.
 
 ### `notification_queue`
 
-Pending notifications waiting to be sent.
+Pending notifications waiting to be sent. Supports both newsletter and report notifications via polymorphic design.
 
 | Column            | Type        | Constraints                            | Description                                    |
 | ----------------- | ----------- | -------------------------------------- | ---------------------------------------------- |
 | id                | uuid        | PRIMARY KEY, DEFAULT gen_random_uuid() | Queue entry ID                                 |
 | user_id           | uuid        | NOT NULL, FK → auth.users(id)          | Recipient user                                 |
-| newsletter_id     | uuid        | FK → newsletters(id)                   | Matched newsletter (or report_id for weekly)   |
+| newsletter_id     | uuid        | FK → newsletters(id)                   | Matched newsletter (NULL for weekly reports)   |
+| report_id         | uuid        | FK → weekly_topic_reports(id)          | Matched report (NULL for daily newsletters)    |
 | rule_id           | uuid        | NOT NULL, FK → notification_rules(id)  | Rule that matched                              |
 | status            | text        | NOT NULL, DEFAULT 'pending'            | Status: pending/sent/failed                    |
 | digest_batch_id   | text        |                                        | Batch ID for grouping (YYYY-MM-DD or YYYY-WXX) |
@@ -197,12 +198,16 @@ Pending notifications waiting to be sent.
 **Foreign Keys**:
 
 - `user_id` → `auth.users(id)` ON DELETE CASCADE
-- `newsletter_id` → `newsletters(id)` ON DELETE CASCADE (nullable for weekly reports)
+- `newsletter_id` → `newsletters(id)` ON DELETE CASCADE (nullable)
+- `report_id` → `weekly_topic_reports(id)` ON DELETE CASCADE (nullable)
 - `rule_id` → `notification_rules(id)` ON DELETE CASCADE
 
-**Note**: For weekly notifications, `newsletter_id` stores the UUID from `weekly_topic_reports.id` instead of a newsletter ID.
+**Polymorphic Design**: Exactly one of `newsletter_id` or `report_id` must be set (enforced by CHECK constraint). Daily notifications use `newsletter_id`, weekly notifications use `report_id`.
 
-**Unique Constraint**: `(user_id, newsletter_id, rule_id)` - prevents duplicate notifications
+**Unique Constraints**: Partial unique indexes prevent duplicate notifications:
+
+- `idx_unique_newsletter_notif` on `(user_id, newsletter_id, rule_id)` WHERE `newsletter_id` IS NOT NULL
+- `idx_unique_report_notif` on `(user_id, report_id, rule_id)` WHERE `report_id` IS NOT NULL
 
 **Status Values**:
 
@@ -221,6 +226,7 @@ Pending notifications waiting to be sent.
 - `idx_notification_queue_user` on `(user_id, status)`
 - `idx_notification_queue_digest` on `(digest_batch_id, status)`
 - `idx_notification_queue_type_status` on `(notification_type, status, created_at)`
+- `idx_notification_queue_report` on `report_id` (partial index WHERE `report_id` IS NOT NULL)
 
 ---
 
@@ -388,11 +394,12 @@ SELECT * FROM get_week_date_range('2026-W05');
 
 ## Migration History
 
-| Version | File                            | Description                                                  | Date       |
-| ------- | ------------------------------- | ------------------------------------------------------------ | ---------- |
-| 001     | `001_notification_system.sql`   | Added notification system (4 tables, triggers, RLS)          | 2026-01-21 |
-| 002     | `002_add_search_term.sql`       | Replaced keywords array with single search_term column       | 2026-01-23 |
-| 003     | `003_weekly_topic_reports.sql`  | Added weekly topic reports (table, delivery_frequency, helpers) | 2026-01-31 |
+| Version | File                               | Description                                                     | Date       |
+| ------- | ---------------------------------- | --------------------------------------------------------------- | ---------- |
+| 001     | `001_notification_system.sql`      | Added notification system (4 tables, triggers, RLS)             | 2026-01-21 |
+| 002     | `002_add_search_term.sql`          | Replaced keywords array with single search_term column          | 2026-01-23 |
+| 003     | `003_weekly_topic_reports.sql`     | Added weekly topic reports (table, delivery_frequency, helpers) | 2026-01-31 |
+| 004     | `004_polymorphic_notifications.sql`| Polymorphic notification_queue (dedicated report_id column)     | 2026-01-31 |
 
 ---
 

--- a/backend/SCHEMA.md
+++ b/backend/SCHEMA.md
@@ -134,19 +134,20 @@ User account data (extends Supabase Auth).
 
 User-defined notification rules.
 
-| Column              | Type        | Constraints                            | Description                    |
-| ------------------- | ----------- | -------------------------------------- | ------------------------------ |
-| id                  | uuid        | PRIMARY KEY, DEFAULT gen_random_uuid() | Rule ID                        |
-| user_id             | uuid        | NOT NULL, FK → auth.users(id)          | Rule owner                     |
-| name                | text        | NOT NULL                               | User-friendly rule name        |
-| is_active           | boolean     | NOT NULL, DEFAULT true                 | Whether rule is enabled        |
-| created_at          | timestamptz | NOT NULL, DEFAULT now()                | Rule creation time             |
-| updated_at          | timestamptz | NOT NULL, DEFAULT now()                | Last update time               |
-| topics              | text[]      | NOT NULL, DEFAULT '{}'                 | Topics to match (MVP)          |
-| search_term         | text        |                                        | Search word or phrase to match |
-| min_relevance_score | integer     |                                        | Minimum relevance score        |
-| source_ids          | integer[]   |                                        | Specific sources to match      |
-| ward_numbers        | text[]      |                                        | Specific wards to match        |
+| Column              | Type        | Constraints                            | Description                     |
+| ------------------- | ----------- | -------------------------------------- | ------------------------------- |
+| id                  | uuid        | PRIMARY KEY, DEFAULT gen_random_uuid() | Rule ID                         |
+| user_id             | uuid        | NOT NULL, FK → auth.users(id)          | Rule owner                      |
+| name                | text        | NOT NULL                               | User-friendly rule name         |
+| is_active           | boolean     | NOT NULL, DEFAULT true                 | Whether rule is enabled         |
+| created_at          | timestamptz | NOT NULL, DEFAULT now()                | Rule creation time              |
+| updated_at          | timestamptz | NOT NULL, DEFAULT now()                | Last update time                |
+| topics              | text[]      | NOT NULL, DEFAULT '{}'                 | Topics to match (MVP)           |
+| search_term         | text        |                                        | Search word or phrase to match  |
+| min_relevance_score | integer     |                                        | Minimum relevance score         |
+| source_ids          | integer[]   |                                        | Specific sources to match       |
+| ward_numbers        | text[]      |                                        | Specific wards to match         |
+| delivery_frequency  | text        | NOT NULL, DEFAULT 'daily'              | Delivery frequency: daily/weekly |
 
 **Foreign Keys**:
 
@@ -172,6 +173,7 @@ User-defined notification rules.
 
 - `idx_notification_rules_user_id` on `user_id`
 - `idx_notification_rules_active` on `(user_id, is_active)`
+- `idx_notification_rules_frequency` on `(delivery_frequency, is_active)`
 
 ---
 
@@ -179,23 +181,26 @@ User-defined notification rules.
 
 Pending notifications waiting to be sent.
 
-| Column          | Type        | Constraints                            | Description                        |
-| --------------- | ----------- | -------------------------------------- | ---------------------------------- |
-| id              | uuid        | PRIMARY KEY, DEFAULT gen_random_uuid() | Queue entry ID                     |
-| user_id         | uuid        | NOT NULL, FK → auth.users(id)          | Recipient user                     |
-| newsletter_id   | uuid        | NOT NULL, FK → newsletters(id)         | Matched newsletter                 |
-| rule_id         | uuid        | NOT NULL, FK → notification_rules(id)  | Rule that matched                  |
-| status          | text        | NOT NULL, DEFAULT 'pending'            | Status: pending/sent/failed        |
-| digest_batch_id | text        |                                        | Batch ID for grouping (YYYY-MM-DD) |
-| created_at      | timestamptz | NOT NULL, DEFAULT now()                | When queued                        |
-| sent_at         | timestamptz |                                        | When sent/failed                   |
-| error_message   | text        |                                        | Error details if failed            |
+| Column            | Type        | Constraints                            | Description                                    |
+| ----------------- | ----------- | -------------------------------------- | ---------------------------------------------- |
+| id                | uuid        | PRIMARY KEY, DEFAULT gen_random_uuid() | Queue entry ID                                 |
+| user_id           | uuid        | NOT NULL, FK → auth.users(id)          | Recipient user                                 |
+| newsletter_id     | uuid        | FK → newsletters(id)                   | Matched newsletter (or report_id for weekly)   |
+| rule_id           | uuid        | NOT NULL, FK → notification_rules(id)  | Rule that matched                              |
+| status            | text        | NOT NULL, DEFAULT 'pending'            | Status: pending/sent/failed                    |
+| digest_batch_id   | text        |                                        | Batch ID for grouping (YYYY-MM-DD or YYYY-WXX) |
+| notification_type | text        | NOT NULL, DEFAULT 'daily'              | Type: daily/weekly                             |
+| created_at        | timestamptz | NOT NULL, DEFAULT now()                | When queued                                    |
+| sent_at           | timestamptz |                                        | When sent/failed                               |
+| error_message     | text        |                                        | Error details if failed                        |
 
 **Foreign Keys**:
 
 - `user_id` → `auth.users(id)` ON DELETE CASCADE
-- `newsletter_id` → `newsletters(id)` ON DELETE CASCADE
+- `newsletter_id` → `newsletters(id)` ON DELETE CASCADE (nullable for weekly reports)
 - `rule_id` → `notification_rules(id)` ON DELETE CASCADE
+
+**Note**: For weekly notifications, `newsletter_id` stores the UUID from `weekly_topic_reports.id` instead of a newsletter ID.
 
 **Unique Constraint**: `(user_id, newsletter_id, rule_id)` - prevents duplicate notifications
 
@@ -215,6 +220,7 @@ Pending notifications waiting to be sent.
 - `idx_notification_queue_status` on `(status, created_at)`
 - `idx_notification_queue_user` on `(user_id, status)`
 - `idx_notification_queue_digest` on `(digest_batch_id, status)`
+- `idx_notification_queue_type_status` on `(notification_type, status, created_at)`
 
 ---
 
@@ -241,7 +247,8 @@ Audit log of sent notifications.
 
 **Delivery Types**:
 
-- `daily_digest` - Daily aggregated email
+- `daily_digest` - Daily aggregated email with matched newsletters
+- `weekly_digest` - Weekly aggregated email with AI-generated topic reports
 
 **Row-Level Security**:
 
@@ -253,6 +260,37 @@ Audit log of sent notifications.
 - `idx_notification_history_user` on `(user_id, sent_at DESC)`
 - `idx_notification_history_batch` on `digest_batch_id`
 - `idx_notification_history_success` on `(success, sent_at DESC)`
+
+---
+
+### `weekly_topic_reports`
+
+AI-generated weekly summaries for specific topics.
+
+| Column           | Type        | Constraints                            | Description                                  |
+| ---------------- | ----------- | -------------------------------------- | -------------------------------------------- |
+| id               | uuid        | PRIMARY KEY, DEFAULT gen_random_uuid() | Report ID                                    |
+| topic            | text        | NOT NULL                               | Topic name (from TOPICS constant)            |
+| week_id          | text        | NOT NULL                               | ISO week identifier (YYYY-WXX)               |
+| report_summary   | text        | NOT NULL                               | AI-generated 2-4 paragraph synthesis         |
+| newsletter_ids   | uuid[]      | NOT NULL                               | Array of newsletter IDs analyzed             |
+| key_developments | jsonb       |                                        | Optional structured facts from Phase 1 LLM   |
+| created_at       | timestamptz | NOT NULL, DEFAULT now()                | When report was generated                    |
+
+**Unique Constraint**: `(topic, week_id)` - Prevents duplicate reports for same topic/week (idempotency)
+
+**Row-Level Security**:
+
+- ✅ All authenticated users can view weekly reports
+- ❌ Only service role can create/update (backend processing only)
+
+**Indexes**:
+
+- `idx_weekly_topic_reports_week` on `week_id`
+- `idx_weekly_topic_reports_topic` on `topic`
+- `idx_weekly_topic_reports_topic_week` on `(topic, week_id)`
+
+**Report Generation**: Reports are generated by `utils.process_weekly_reports` for topics with active weekly subscribers.
 
 ---
 
@@ -286,6 +324,34 @@ Audit log of sent notifications.
 
 ---
 
+### `get_active_weekly_topics() → TABLE(topic text)`
+
+**Helper Function** - Returns list of topics that have active weekly subscribers.
+
+**Usage**: Used by `process_weekly_reports.py` to optimize report generation (only process topics with subscribers).
+
+**Returns**: Distinct list of topics from active weekly notification rules.
+
+**Permissions**: Granted to `authenticated` and `service_role`.
+
+---
+
+### `get_week_date_range(week_id_param text) → TABLE(week_start date, week_end date)`
+
+**Helper Function** - Converts ISO week ID (YYYY-WXX) to date range.
+
+**Usage**: Used to query newsletters by week for report generation.
+
+**Example**:
+```sql
+SELECT * FROM get_week_date_range('2026-W05');
+-- Returns: week_start = 2026-01-26, week_end = 2026-02-01
+```
+
+**Permissions**: Granted to `authenticated` and `service_role`.
+
+---
+
 ## Data Flow
 
 ### Newsletter Ingestion
@@ -296,22 +362,37 @@ Audit log of sent notifications.
 4. Insert into `newsletters` table
 5. **NEW**: Match against `notification_rules` → queue in `notification_queue`
 
-### Notification Delivery
+### Daily Notification Delivery
 
-1. Daily cron/GitHub Action runs `process_notification_queue.py`
+1. Daily cron/GitHub Action runs `process_notification_queue.py --daily-digest`
 2. Group pending notifications by `user_id` and `digest_batch_id`
 3. Send ONE email per user via Resend API
 4. Update `notification_queue` status to 'sent'
-5. Record delivery in `notification_history`
+5. Record delivery in `notification_history` with `delivery_type='daily_digest'`
+
+### Weekly Report Generation and Delivery
+
+1. Weekly cron runs `utils.process_weekly_reports` (e.g., Monday morning)
+2. Query `get_active_weekly_topics()` to find topics with subscribers
+3. For each active topic:
+   - Fetch newsletters tagged with topic from previous week
+   - Extract structured facts via LLM (Phase 1)
+   - Synthesize weekly summary via LLM (Phase 2)
+   - Store in `weekly_topic_reports` table
+4. Run `notifications.weekly_notification_queue` to queue notifications
+5. Weekly cron runs `process_notification_queue.py --weekly-digest`
+6. Group by user, send ONE email per user with all subscribed topics
+7. Record delivery with `delivery_type='weekly_digest'`
 
 ---
 
 ## Migration History
 
-| Version | File                          | Description                                            | Date       |
-| ------- | ----------------------------- | ------------------------------------------------------ | ---------- |
-| 001     | `001_notification_system.sql` | Added notification system (4 tables, triggers, RLS)    | 2026-01-21 |
-| 002     | `002_add_search_term.sql`     | Replaced keywords array with single search_term column | 2026-01-23 |
+| Version | File                            | Description                                                  | Date       |
+| ------- | ------------------------------- | ------------------------------------------------------------ | ---------- |
+| 001     | `001_notification_system.sql`   | Added notification system (4 tables, triggers, RLS)          | 2026-01-21 |
+| 002     | `002_add_search_term.sql`       | Replaced keywords array with single search_term column       | 2026-01-23 |
+| 003     | `003_weekly_topic_reports.sql`  | Added weekly topic reports (table, delivery_frequency, helpers) | 2026-01-31 |
 
 ---
 
@@ -359,6 +440,58 @@ FROM newsletters
 WHERE received_date >= CURRENT_DATE - INTERVAL '30 days'
 GROUP BY DATE(received_date)
 ORDER BY date DESC;
+```
+
+### Weekly report generation status
+
+```sql
+SELECT
+  week_id,
+  topic,
+  array_length(newsletter_ids, 1) AS newsletters_analyzed,
+  LENGTH(report_summary) AS summary_length,
+  created_at
+FROM weekly_topic_reports
+ORDER BY week_id DESC, topic;
+```
+
+### Topics with active weekly subscribers
+
+```sql
+SELECT * FROM get_active_weekly_topics()
+ORDER BY topic;
+```
+
+### Weekly digest delivery statistics
+
+```sql
+SELECT
+  digest_batch_id AS week_id,
+  COUNT(DISTINCT user_id) AS users,
+  COUNT(*) AS total_reports_sent
+FROM notification_history
+WHERE delivery_type = 'weekly_digest'
+GROUP BY digest_batch_id
+ORDER BY digest_batch_id DESC
+LIMIT 10;
+```
+
+### Fetch newsletters for weekly report generation
+
+```sql
+SELECT
+  n.id,
+  n.subject,
+  n.plain_text,
+  n.received_date,
+  s.name AS source_name,
+  s.ward_number
+FROM newsletters n
+JOIN sources s ON n.source_id = s.id
+CROSS JOIN get_week_date_range('2026-W05') AS week_range
+WHERE 'bike_lanes' = ANY(n.topics)
+  AND n.received_date::DATE BETWEEN week_range.week_start AND week_range.week_end
+ORDER BY n.received_date DESC;
 ```
 
 ---

--- a/backend/SCHEMA.md
+++ b/backend/SCHEMA.md
@@ -153,13 +153,25 @@ User-defined notification rules.
 
 - `user_id` → `auth.users(id)` ON DELETE CASCADE
 
-**Application Constraint**: Maximum 5 rules per user (enforced in API)
+**Application Constraints**:
+- Maximum 5 rules per user (enforced in API)
+- Ward filters (`ward_numbers`) only allowed for `delivery_frequency = 'daily'`
+- Weekly rules must have at least one topic; search terms not supported
 
-**Matching Logic**: All filters are AND-ed together.
+**Database Constraint**:
+- `weekly_rules_no_ward_filter`: Prevents ward_numbers on weekly rules (added in migration 003)
+
+**Matching Logic** (applies to daily digest notifications only):
 
 - `topics`: Matches if newsletter has ANY of the selected topics.
 - `search_term`: Matches if newsletter contains the exact search phrase (case-insensitive substring).
-- If both are present, newsletter must match BOTH criteria.
+- `ward_numbers`: Matches if newsletter is from ANY of the specified wards.
+- All filters are AND-ed together (newsletter must match all specified criteria).
+
+**Weekly Summary Behavior**:
+- Weekly summaries are topic-based only (no search term or ward filtering)
+- Reports cover citywide activity for selected topics
+- Delivered every Monday morning
 
 **Row-Level Security**:
 

--- a/backend/docs/ARCHITECTURE_POLYMORPHIC_NOTIFICATIONS.md
+++ b/backend/docs/ARCHITECTURE_POLYMORPHIC_NOTIFICATIONS.md
@@ -1,0 +1,85 @@
+# Architectural Decision: Polymorphic Notifications in `notification_queue`
+
+## 1. The Problem Statement
+
+The system is evolving from a single-content notification system (Daily Newsletter Digests) to a multi-content system (adding Weekly Topic Reports). 
+
+Currently, the `notification_queue` table is designed around the `newsletters` table. It has a column `newsletter_id` with a strict **Foreign Key (FK) constraint** pointing to `public.newsletters(id)`.
+
+**The conflict arises because:**
+1. Weekly Topic Reports are stored in a separate table: `weekly_topic_reports`.
+2. The current implementation attempts to store the `id` from `weekly_topic_reports` into the `notification_queue.newsletter_id` column.
+3. This triggers a database error (`23503: foreign key violation`) because the Report ID does not exist in the Newsletter table.
+4. Furthermore, Supabase (PostgREST) cannot perform automatic joins to fetch report content because it relies on formal FK relationships to discover join paths.
+
+### References:
+- **Table Definition**: `backend/sql/schema.sql` (see `notification_queue`)
+- **Failing Script**: `backend/notifications/weekly_notification_queue.py` (insertion logic)
+- **Failing Fetcher**: `backend/notifications/process_notification_queue.py` (join logic)
+
+---
+
+## 2. Solution Options
+
+### Option A: Overloaded Column (The "Quick Fix")
+Drop the FK constraint on `newsletter_id` and use it as a generic "Content ID".
+- **Pros**: Minimal code changes; no new columns.
+- **Cons**: Total loss of referential integrity; no `ON DELETE CASCADE`; requires manual "two-step" fetching in Python (cannot join in one DB call).
+
+### Option B: Dedicated Columns (Best Practice for SQL)
+Add a dedicated `report_id` column to `notification_queue` with its own FK to `weekly_topic_reports`.
+- **Pros**: Full referential integrity; Supabase auto-joins work perfectly; `ON DELETE CASCADE` works; clear and self-documenting.
+- **Cons**: Requires migration to add column; requires updating all insert/select logic in the backend.
+
+### Option C: Generic Polymorphic Association (Extensible)
+Use two columns: `content_id` (UUID) and `content_type` (TEXT: 'newsletter' or 'report').
+- **Pros**: Infinite extensibility (easy to add "Urgent Alerts", "Monthly Summaries" later).
+- **Cons**: Lacks formal FK constraints at the DB level (standard SQL limitation); requires complex logic to join.
+
+---
+
+## 3. Best Practice Recommendation
+
+**Option B (Dedicated Columns)** is the recommended best practice for this project.
+
+While it requires more initial refactoring, it aligns with relational database principles and leverages the power of the Supabase/PostgREST engine. 
+
+### Why Option B?
+1. **Performance**: You can fetch the queue item, the rule, AND the content (whether it's a newsletter or a report) in a single optimized query using `.select("*, newsletter:newsletters(*), report:weekly_topic_reports(*)")`.
+2. **Safety**: The database guarantees that you can't have a notification pointing to a deleted report.
+3. **Clarity**: A developer looking at the table immediately understands that a notification can be triggered by one of two distinct types of content.
+
+---
+
+## 4. Implementation Roadmap for Future Agent
+
+If implementing **Option B**, the following steps should be taken:
+
+### Step 1: Migration (`backend/migrations/004_dedicated_notification_columns.sql`)
+```sql
+-- 1. Add the new column
+ALTER TABLE notification_queue 
+ADD COLUMN report_id UUID REFERENCES weekly_topic_reports(id) ON DELETE CASCADE;
+
+-- 2. Make the old column nullable (if it wasn't already)
+ALTER TABLE notification_queue 
+ALTER COLUMN newsletter_id DROP NOT NULL;
+
+-- 3. Update the unique constraint to be smarter
+ALTER TABLE notification_queue DROP CONSTRAINT IF EXISTS unique_notification;
+
+-- Ensure a user only gets one notification per specific piece of content/rule
+CREATE UNIQUE INDEX idx_unique_newsletter_notif ON notification_queue (user_id, newsletter_id, rule_id) WHERE newsletter_id IS NOT NULL;
+CREATE UNIQUE INDEX idx_unique_report_notif ON notification_queue (user_id, report_id, rule_id) WHERE report_id IS NOT NULL;
+```
+
+### Step 2: Update Queuing Logic
+Update `backend/notifications/weekly_notification_queue.py` to insert into `report_id` instead of `newsletter_id`.
+
+### Step 3: Update Fetching Logic
+Update `backend/notifications/process_notification_queue.py`:
+- Refactor `_fetch_weekly_notifications` to use a single `.select()` join now that the FK exists.
+- Update the grouping logic to check for the presence of `report_id`.
+
+### Step 4: Update History Recording
+Ensure `notification_history` (which uses a `UUID[]` array for `newsletter_ids`) is updated to store whichever ID was used, or consider adding a `report_ids` column there as well for parity.

--- a/backend/ingest/email/process_emails.py
+++ b/backend/ingest/email/process_emails.py
@@ -155,10 +155,12 @@ def process_new_newsletters() -> None:
                 # Optional: Process with LLM if enabled
                 if ENABLE_LLM:
                     try:
-                        from processing.llm_processor import process_with_ollama
+                        from processing.llm_processor import extract_newsletter_metadata
 
                         OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "gpt-oss:20b")
-                        llm_result = process_with_ollama(newsletter, OLLAMA_MODEL)
+                        llm_result = extract_newsletter_metadata(
+                            newsletter, OLLAMA_MODEL
+                        )
                         newsletter.update(llm_result)
                         print("  LLM processing complete")
                     except ImportError:

--- a/backend/ingest/scraper/process_scraped_newsletters.py
+++ b/backend/ingest/scraper/process_scraped_newsletters.py
@@ -123,10 +123,12 @@ def process_scraped_newsletters(source_id: int, limit: int | None = None) -> Non
             # LLM processing or delay
             if ENABLE_LLM:
                 try:
-                    from processing.llm_processor import process_with_ollama
+                    from processing.llm_processor import extract_newsletter_metadata
 
                     print("  LLM processing...")
-                    llm_result = process_with_ollama(newsletter_data, OLLAMA_MODEL)
+                    llm_result = extract_newsletter_metadata(
+                        newsletter_data, OLLAMA_MODEL
+                    )
                     newsletter_data.update(llm_result)
                     print("  ✓ LLM complete")
 

--- a/backend/migrations/003_weekly_rules_no_ward_filter.sql
+++ b/backend/migrations/003_weekly_rules_no_ward_filter.sql
@@ -1,0 +1,24 @@
+-- Migration: Remove ward filters from weekly notification rules
+-- Weekly summaries are citywide by design and should not have ward filters
+-- Created: 2026-01-31
+
+-- Clear ward_numbers from existing weekly rules
+UPDATE notification_rules
+SET ward_numbers = NULL
+WHERE delivery_frequency = 'weekly'
+  AND ward_numbers IS NOT NULL
+  AND array_length(ward_numbers, 1) > 0;
+
+-- Add check constraint to prevent ward filters on weekly rules
+-- This ensures data integrity at the database level
+ALTER TABLE notification_rules
+ADD CONSTRAINT weekly_rules_no_ward_filter
+CHECK (
+  delivery_frequency != 'weekly'
+  OR ward_numbers IS NULL
+  OR array_length(ward_numbers, 1) IS NULL
+);
+
+-- Add comment explaining the constraint
+COMMENT ON CONSTRAINT weekly_rules_no_ward_filter ON notification_rules IS
+'Weekly summaries cover citywide activity and cannot be filtered by ward. Only daily digest notifications support ward filtering.';

--- a/backend/migrations/003_weekly_topic_reports.sql
+++ b/backend/migrations/003_weekly_topic_reports.sql
@@ -116,18 +116,12 @@ GRANT EXECUTE ON FUNCTION get_week_date_range TO service_role;
 -- ============================================================================
 -- 6. ROW-LEVEL SECURITY (RLS)
 -- ============================================================================
--- Weekly reports are publicly readable (no sensitive data)
--- Only service role can insert/update (backend processing)
+-- Weekly reports are backend-only (no frontend access needed)
+-- Only service role can access (backend processing and email composition)
 
 ALTER TABLE weekly_topic_reports ENABLE ROW LEVEL SECURITY;
 
--- Allow all authenticated users to read reports
-CREATE POLICY "Anyone can view weekly topic reports"
-    ON weekly_topic_reports FOR SELECT
-    TO authenticated
-    USING (true);
-
--- Service role has full access (bypasses RLS by default, but explicit policy for clarity)
+-- Service role has full access for backend operations
 CREATE POLICY "Service role can manage weekly topic reports"
     ON weekly_topic_reports FOR ALL
     TO service_role

--- a/backend/migrations/003_weekly_topic_reports.sql
+++ b/backend/migrations/003_weekly_topic_reports.sql
@@ -1,0 +1,201 @@
+-- Migration: Weekly Topic Reports
+-- Description: Add weekly topic reports table and update notification_rules for delivery frequency
+-- Date: 2026-01-31
+
+-- ============================================================================
+-- 1. WEEKLY TOPIC REPORTS TABLE
+-- ============================================================================
+-- Stores AI-generated weekly summaries for specific topics
+-- One report per topic per week, generated when at least one user subscribes
+
+CREATE TABLE IF NOT EXISTS weekly_topic_reports (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    topic TEXT NOT NULL,
+    week_id TEXT NOT NULL, -- Format: YYYY-WXX (ISO week number, e.g., "2026-W05")
+    report_summary TEXT NOT NULL, -- AI-generated 2-4 paragraph synthesis
+    newsletter_ids UUID[] NOT NULL, -- Newsletters analyzed for this report
+    key_developments JSONB, -- Optional structured facts from Phase 1 extraction
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Prevent duplicate reports for same topic/week (idempotency)
+    CONSTRAINT unique_topic_week UNIQUE (topic, week_id)
+);
+
+-- Indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_weekly_topic_reports_week ON weekly_topic_reports(week_id);
+CREATE INDEX IF NOT EXISTS idx_weekly_topic_reports_topic ON weekly_topic_reports(topic);
+CREATE INDEX IF NOT EXISTS idx_weekly_topic_reports_topic_week ON weekly_topic_reports(topic, week_id);
+
+-- ============================================================================
+-- 2. UPDATE NOTIFICATION_RULES TABLE
+-- ============================================================================
+-- Add delivery_frequency column to support daily vs weekly digests
+-- Defaults to 'daily' for backward compatibility with existing rules
+
+ALTER TABLE notification_rules
+ADD COLUMN IF NOT EXISTS delivery_frequency TEXT DEFAULT 'daily'
+CHECK (delivery_frequency IN ('daily', 'weekly'));
+
+-- Index for efficient filtering by frequency
+CREATE INDEX IF NOT EXISTS idx_notification_rules_frequency
+ON notification_rules(delivery_frequency, is_active);
+
+-- ============================================================================
+-- 3. UPDATE NOTIFICATION_QUEUE TABLE
+-- ============================================================================
+-- Make newsletter_id nullable to support weekly report notifications
+-- Weekly notifications will store report_id in this field
+
+ALTER TABLE notification_queue
+ALTER COLUMN newsletter_id DROP NOT NULL;
+
+-- Add notification_type column to distinguish daily vs weekly notifications
+ALTER TABLE notification_queue
+ADD COLUMN IF NOT EXISTS notification_type TEXT DEFAULT 'daily'
+CHECK (notification_type IN ('daily', 'weekly'));
+
+-- Update index to include notification_type
+CREATE INDEX IF NOT EXISTS idx_notification_queue_type_status
+ON notification_queue(notification_type, status, created_at);
+
+-- ============================================================================
+-- 4. HELPER FUNCTION: GET ACTIVE WEEKLY TOPICS
+-- ============================================================================
+-- Returns list of topics that have active weekly subscribers
+-- Used to optimize report generation (only process topics with subscribers)
+
+CREATE OR REPLACE FUNCTION get_active_weekly_topics()
+RETURNS TABLE(topic TEXT) AS $$
+    SELECT DISTINCT unnest(topics) AS topic
+    FROM notification_rules
+    WHERE is_active = true
+      AND delivery_frequency = 'weekly';
+$$ LANGUAGE SQL STABLE;
+
+-- Grant execute permission to authenticated users and service role
+GRANT EXECUTE ON FUNCTION get_active_weekly_topics TO authenticated;
+GRANT EXECUTE ON FUNCTION get_active_weekly_topics TO service_role;
+
+-- ============================================================================
+-- 5. HELPER FUNCTION: GET WEEK DATE RANGE
+-- ============================================================================
+-- Converts ISO week ID (YYYY-WXX) to date range for querying newsletters
+-- Returns (start_date, end_date) tuple for the week
+
+CREATE OR REPLACE FUNCTION get_week_date_range(week_id_param TEXT)
+RETURNS TABLE(week_start DATE, week_end DATE) AS $$
+DECLARE
+    year_val INTEGER;
+    week_val INTEGER;
+    jan_4 DATE;
+    week_1_monday DATE;
+BEGIN
+    -- Parse YYYY-WXX format
+    year_val := CAST(SUBSTRING(week_id_param FROM 1 FOR 4) AS INTEGER);
+    week_val := CAST(SUBSTRING(week_id_param FROM 7) AS INTEGER);
+
+    -- ISO week 1 is the first week containing a Thursday
+    -- January 4th is always in week 1
+    jan_4 := MAKE_DATE(year_val, 1, 4);
+
+    -- Find the Monday of week 1
+    week_1_monday := jan_4 - CAST(EXTRACT(ISODOW FROM jan_4) - 1 AS INTEGER);
+
+    -- Calculate start and end of target week
+    week_start := week_1_monday + CAST((week_val - 1) * 7 AS INTEGER);
+    week_end := week_start + 6;
+
+    RETURN NEXT;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- Grant execute permission
+GRANT EXECUTE ON FUNCTION get_week_date_range TO authenticated;
+GRANT EXECUTE ON FUNCTION get_week_date_range TO service_role;
+
+-- ============================================================================
+-- 6. ROW-LEVEL SECURITY (RLS)
+-- ============================================================================
+-- Weekly reports are publicly readable (no sensitive data)
+-- Only service role can insert/update (backend processing)
+
+ALTER TABLE weekly_topic_reports ENABLE ROW LEVEL SECURITY;
+
+-- Allow all authenticated users to read reports
+CREATE POLICY "Anyone can view weekly topic reports"
+    ON weekly_topic_reports FOR SELECT
+    TO authenticated
+    USING (true);
+
+-- Service role has full access (bypasses RLS by default, but explicit policy for clarity)
+CREATE POLICY "Service role can manage weekly topic reports"
+    ON weekly_topic_reports FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- ============================================================================
+-- 7. SAMPLE QUERY: FETCH NEWSLETTERS FOR WEEKLY REPORT
+-- ============================================================================
+-- Example query for fetching newsletters for a topic within a specific week
+-- Used by backend report generation code
+
+-- EXAMPLE USAGE:
+-- SELECT
+--     n.id,
+--     n.subject,
+--     n.plain_text,
+--     n.received_date,
+--     s.name AS source_name,
+--     s.ward_number
+-- FROM newsletters n
+-- JOIN sources s ON n.source_id = s.id
+-- CROSS JOIN get_week_date_range('2026-W05') AS week_range
+-- WHERE 'bike_lanes' = ANY(n.topics)
+--   AND n.received_date::DATE BETWEEN week_range.week_start AND week_range.week_end
+-- ORDER BY n.received_date DESC;
+
+-- ============================================================================
+-- ROLLBACK INSTRUCTIONS (if needed)
+-- ============================================================================
+-- To undo this migration, run:
+--
+-- DROP FUNCTION IF EXISTS get_week_date_range(TEXT);
+-- DROP FUNCTION IF EXISTS get_active_weekly_topics();
+-- DROP INDEX IF EXISTS idx_notification_queue_type_status;
+-- ALTER TABLE notification_queue DROP COLUMN IF EXISTS notification_type;
+-- ALTER TABLE notification_queue ALTER COLUMN newsletter_id SET NOT NULL;
+-- DROP INDEX IF EXISTS idx_notification_rules_frequency;
+-- ALTER TABLE notification_rules DROP COLUMN IF EXISTS delivery_frequency;
+-- DROP INDEX IF EXISTS idx_weekly_topic_reports_topic_week;
+-- DROP INDEX IF EXISTS idx_weekly_topic_reports_topic;
+-- DROP INDEX IF EXISTS idx_weekly_topic_reports_week;
+-- DROP TABLE IF EXISTS weekly_topic_reports CASCADE;
+
+-- ============================================================================
+-- POST-MIGRATION VALIDATION
+-- ============================================================================
+-- After running this migration, verify:
+
+-- 1. Check that new table exists
+-- SELECT COUNT(*) FROM weekly_topic_reports;
+-- (Should return 0 initially)
+
+-- 2. Check that delivery_frequency column exists on notification_rules
+-- SELECT delivery_frequency, COUNT(*)
+-- FROM notification_rules
+-- GROUP BY delivery_frequency;
+-- (Should show all existing rules have 'daily')
+
+-- 3. Test helper function
+-- SELECT * FROM get_active_weekly_topics();
+-- (Should return empty set if no weekly rules yet)
+
+-- 4. Test date range function
+-- SELECT * FROM get_week_date_range('2026-W05');
+-- (Should return week_start = 2026-01-26, week_end = 2026-02-01)
+
+-- 5. Verify indexes created
+-- SELECT indexname FROM pg_indexes
+-- WHERE tablename = 'weekly_topic_reports';
+-- (Should show 3 indexes)

--- a/backend/migrations/004_polymorphic_notifications.sql
+++ b/backend/migrations/004_polymorphic_notifications.sql
@@ -1,0 +1,42 @@
+-- Migration 004: Polymorphic Notifications
+-- Add dedicated report_id column to notification_queue to support both newsletters and weekly reports
+-- Implements "Option B (Dedicated Columns)" from backend/docs/ARCHITECTURE_POLYMORPHIC_NOTIFICATIONS.md
+
+-- Step 1: Add the new report_id column
+ALTER TABLE notification_queue
+ADD COLUMN report_id UUID REFERENCES weekly_topic_reports(id) ON DELETE CASCADE;
+
+-- Step 2: Make newsletter_id nullable (since we now support two content types)
+ALTER TABLE notification_queue
+ALTER COLUMN newsletter_id DROP NOT NULL;
+
+-- Step 3: Add constraint to ensure exactly one ID is present
+ALTER TABLE notification_queue
+ADD CONSTRAINT check_one_content_id CHECK (
+  (newsletter_id IS NOT NULL AND report_id IS NULL) OR
+  (newsletter_id IS NULL AND report_id IS NOT NULL)
+);
+
+-- Step 4: Drop old unique constraint
+ALTER TABLE notification_queue DROP CONSTRAINT IF EXISTS unique_notification;
+
+-- Step 5: Create partial unique indexes for each content type
+-- Ensures a user only gets one notification per newsletter/rule combination
+CREATE UNIQUE INDEX idx_unique_newsletter_notif
+ON notification_queue (user_id, newsletter_id, rule_id)
+WHERE newsletter_id IS NOT NULL;
+
+-- Ensures a user only gets one notification per report/rule combination
+CREATE UNIQUE INDEX idx_unique_report_notif
+ON notification_queue (user_id, report_id, rule_id)
+WHERE report_id IS NOT NULL;
+
+-- Step 6: Add index on report_id for query performance
+CREATE INDEX idx_notification_queue_report
+ON notification_queue (report_id)
+WHERE report_id IS NOT NULL;
+
+-- Step 7: Add notification_type column to schema if not already exists (was added in migration 003)
+-- This migration assumes notification_type already exists from migration 003
+-- If running migrations out of order, uncomment:
+-- ALTER TABLE notification_queue ADD COLUMN IF NOT EXISTS notification_type TEXT NOT NULL DEFAULT 'daily';

--- a/backend/models/notification.py
+++ b/backend/models/notification.py
@@ -28,6 +28,7 @@ class NotificationRule(BaseModel):
     source_ids: list[str] = Field(default_factory=list)
     ward_numbers: list[WardNumber] = Field(default_factory=list)
     is_active: bool = True
+    delivery_frequency: str = Field(default="daily", pattern="^(daily|weekly)$")
 
 
 class RuleMatch(BaseModel):
@@ -43,10 +44,11 @@ class NotificationQueueEntry(BaseModel):
 
     id: int
     user_id: UserID
-    newsletter_id: NewsletterID
+    newsletter_id: NewsletterID | None = None  # Nullable for weekly reports
     rule_id: RuleID
     status: str = Field(..., pattern="^(pending|sent|failed)$")
     digest_batch_id: BatchID
+    notification_type: str = Field(default="daily", pattern="^(daily|weekly)$")
     created_at: datetime
     sent_at: datetime | None = None
     error_message: str | None = None

--- a/backend/models/weekly_report.py
+++ b/backend/models/weekly_report.py
@@ -1,0 +1,45 @@
+"""Pydantic models for weekly topic reports."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from models.types import NewsletterID
+
+
+class KeyDevelopment(BaseModel):
+    """Individual development/event extracted from newsletters."""
+
+    description: str = Field(..., max_length=500)
+    newsletter_ids: list[NewsletterID] = Field(default_factory=list)
+    wards: list[str] = Field(default_factory=list)
+
+
+class WeeklyTopicReport(BaseModel):
+    """Weekly aggregated report for a specific topic."""
+
+    id: str
+    topic: str
+    week_id: str  # Format: YYYY-WXX
+    report_summary: str = Field(..., max_length=3000)
+    newsletter_ids: list[NewsletterID]
+    key_developments: list[KeyDevelopment] | None = None
+    created_at: datetime
+
+
+# LLM Response Schemas
+class FactExtraction(BaseModel):
+    """Phase 1: Extract structured facts from newsletters."""
+
+    developments: list[KeyDevelopment] = Field(
+        description="Key developments, decisions, or announcements"
+    )
+
+
+class WeeklySynthesis(BaseModel):
+    """Phase 2: Synthesize facts into narrative summary."""
+
+    summary: str = Field(
+        max_length=3000,
+        description="2-4 paragraph weekly summary of topic activity",
+    )

--- a/backend/models/weekly_report.py
+++ b/backend/models/weekly_report.py
@@ -10,7 +10,7 @@ from models.types import NewsletterID
 class KeyDevelopment(BaseModel):
     """Individual development/event extracted from newsletters."""
 
-    description: str = Field(..., max_length=500)
+    description: str = Field(..., max_length=2000)
     newsletter_ids: list[NewsletterID] = Field(default_factory=list)
     wards: list[str] = Field(default_factory=list)
 

--- a/backend/notifications/email_sender.py
+++ b/backend/notifications/email_sender.py
@@ -189,6 +189,10 @@ def send_digest(
             prepared_data = _prepare_weekly_report_data(notifications)
             subject = f"Your Weekly Chicago Alderman Topic Digest ({len(prepared_data)} topics)"
 
+        # Check for empty content - don't send empty digests
+        if not prepared_data:
+            return {"success": False, "error": "Empty digest content"}
+
         # Build email content using templates
         html_body = _build_digest_html(
             prepared_data, digest_type, preferences_url, unsubscribe_url

--- a/backend/notifications/email_sender.py
+++ b/backend/notifications/email_sender.py
@@ -1,14 +1,22 @@
 """
 Email sending via Resend API for notification system.
 
-Handles sending daily digest emails to users with matched newsletters.
+Handles sending digest emails (daily and weekly) to users with matched content.
 """
 
 import os
+from enum import Enum
 from typing import Any
 from datetime import datetime
 import resend
 from notifications.unsubscribe_tokens import generate_unsubscribe_token
+
+
+class DigestType(Enum):
+    """Type of digest email to send."""
+
+    DAILY = "daily"
+    WEEKLY = "weekly"
 
 
 # Initialize Resend with API key from environment
@@ -132,19 +140,24 @@ def _prepare_newsletter_data(
     return prepared_newsletters
 
 
-def send_daily_digest(
+def send_digest(
     user_id: str,
     user_email: str,
     notifications: list[dict[str, Any]],
+    digest_type: DigestType,
     preferences_url: str | None = None,
 ) -> dict[str, Any]:
     """
-    Send a daily digest email with all matched newsletters.
+    Send a digest email (daily or weekly) with matched content.
+
+    Generic digest sender that handles both daily newsletter digests and
+    weekly topic report digests using template-based rendering.
 
     Args:
         user_id: User's unique identifier (for generating unsubscribe token)
         user_email: Recipient email address
         notifications: List of notification records (from notification_queue)
+        digest_type: Type of digest (DigestType.DAILY or DigestType.WEEKLY)
         preferences_url: URL to preferences page for managing notifications
 
     Returns:
@@ -167,16 +180,20 @@ def send_daily_digest(
             "NOTIFICATION_FROM_EMAIL", "newsletter-notifications@open-advocacy.com"
         )
 
-        # Prepare all newsletter data once (grouping, extraction, formatting)
-        prepared_newsletters = _prepare_newsletter_data(notifications)
+        # Prepare data based on digest type
+        if digest_type == DigestType.DAILY:
+            prepared_data = _prepare_newsletter_data(notifications)
+            subject = f"Your Daily Chicago Alderman Newsletter Digest ({len(prepared_data)} newsletters)"
+        else:  # WEEKLY
+            prepared_data = _prepare_weekly_report_data(notifications)
+            subject = f"Your Weekly Chicago Alderman Topic Digest ({len(prepared_data)} topics)"
 
-        # Build email content (formatters only handle presentation)
-        subject = f"Your Daily Chicago Alderman Newsletter Digest ({len(prepared_newsletters)} newsletters)"
+        # Build email content using templates
         html_body = _build_digest_html(
-            prepared_newsletters, preferences_url, unsubscribe_url
+            prepared_data, digest_type, preferences_url, unsubscribe_url
         )
         text_body = _build_digest_text(
-            prepared_newsletters, preferences_url, unsubscribe_url
+            prepared_data, digest_type, preferences_url, unsubscribe_url
         )
 
         # Send email via Resend
@@ -200,146 +217,36 @@ def send_daily_digest(
         return {"success": False, "error": str(e)}
 
 
-def _build_digest_html(
-    prepared_newsletters: list[dict[str, Any]],
-    preferences_url: str,
-    unsubscribe_url: str,
-) -> str:
+def send_daily_digest(
+    user_id: str,
+    user_email: str,
+    notifications: list[dict[str, Any]],
+    preferences_url: str | None = None,
+) -> dict[str, Any]:
     """
-    Build HTML email body for daily digest.
+    Send a daily digest email with all matched newsletters.
+
+    Wrapper around send_digest() for backward compatibility.
 
     Args:
-        prepared_newsletters: List of dicts with all newsletter data pre-extracted and formatted
-        preferences_url: URL to preferences page
-        unsubscribe_url: One-click unsubscribe URL with signed token
+        user_id: User's unique identifier (for generating unsubscribe token)
+        user_email: Recipient email address
+        notifications: List of notification records (from notification_queue)
+        preferences_url: URL to preferences page for managing notifications
 
     Returns:
-        HTML string
+        Dictionary with 'success' (bool), 'email_id' (str if success), 'error' (str if failed)
     """
+    return send_digest(
+        user_id, user_email, notifications, DigestType.DAILY, preferences_url
+    )
 
-    # Build HTML
-    html = """
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Daily Newsletter Digest</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #f5f5f5;
-        }
-        .container {
-            background-color: white;
-            padding: 30px;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        }
-        .header {
-            border-bottom: 3px solid #2563eb;
-            padding-bottom: 15px;
-            margin-bottom: 25px;
-        }
-        h1 {
-            margin: 0;
-            color: #1e40af;
-            font-size: 24px;
-        }
-        .subtitle {
-            color: #6b7280;
-            margin: 5px 0 0 0;
-            font-size: 14px;
-        }
-        .newsletter {
-            border-left: 4px solid #e5e7eb;
-            padding: 15px;
-            margin-bottom: 20px;
-            background-color: #f9fafb;
-        }
-        .newsletter-title {
-            font-size: 18px;
-            font-weight: 600;
-            color: #1f2937;
-            margin: 0 0 8px 0;
-        }
-        .newsletter-meta {
-            color: #6b7280;
-            font-size: 13px;
-            margin-bottom: 10px;
-        }
-        .newsletter-summary {
-            margin: 10px 0;
-            color: #374151;
-        }
-        .topics {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 6px;
-            margin: 10px 0;
-        }
-        .topic {
-            background-color: #dbeafe;
-            color: #1e40af;
-            padding: 4px 10px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-        }
-        .matched-rules {
-            background-color: #f0fdf4;
-            border-left: 3px solid #10b981;
-            padding: 8px 12px;
-            margin: 10px 0;
-            font-size: 13px;
-            color: #065f46;
-        }
-        .matched-rules strong {
-            color: #047857;
-        }
-        .read-more {
-            display: inline-block;
-            margin-top: 8px;
-            color: #2563eb;
-            text-decoration: none;
-            font-weight: 500;
-        }
-        .read-more:hover {
-            text-decoration: underline;
-        }
-        .footer {
-            margin-top: 30px;
-            padding-top: 20px;
-            border-top: 1px solid #e5e7eb;
-            font-size: 13px;
-            color: #6b7280;
-            text-align: center;
-        }
-        .footer a {
-            color: #2563eb;
-            text-decoration: none;
-        }
-        .footer a:hover {
-            text-decoration: underline;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="header">
-            <h1>Daily Chicago Aldermen Newsletter Digest</h1>
-            <p class="subtitle">Chicago aldermen newsletters matching your interests</p>
-        </div>
-"""
 
-    # Add each newsletter (all data already extracted and formatted)
+def _render_daily_content_html(prepared_newsletters: list[dict[str, Any]]) -> str:
+    """Render daily digest content section (newsletter cards) as HTML."""
+    content = ""
     for newsletter in prepared_newsletters:
-        html += f"""
+        content += f"""
         <div class="newsletter">
             <h2 class="newsletter-title">{newsletter["title"]}</h2>
             <div class="newsletter-meta">
@@ -350,40 +257,259 @@ def _build_digest_html(
         # Add matched rules indicator
         if newsletter["matched_rules"]:
             rules_text = ", ".join(newsletter["matched_rules"])
-            html += f"""
+            content += f"""
             <div class="matched-rules">
                 <strong>✓ Matched your rules:</strong> {rules_text}
             </div>
 """
 
         if newsletter["summary"]:
-            html += f"""
+            content += f"""
             <div class="newsletter-summary">{newsletter["summary"]}</div>
 """
 
         if newsletter["topics"]:
-            html += """
+            content += """
             <div class="topics">
 """
-            for topic in newsletter["topics"][:5]:  # Limit to 5 topics for readability
-                html += f"""
+            for topic in newsletter["topics"][:5]:  # Limit to 5 topics
+                content += f"""
                 <span class="topic">{topic}</span>
 """
-            html += """
+            content += """
             </div>
 """
 
-        html += f"""
+        content += f"""
             <a href="{newsletter["newsletter_url"]}" class="read-more">Read full newsletter →</a>
         </div>
 """
+    return content
 
-    # Add footer
-    html += f"""
+
+def _render_weekly_content_html(prepared_reports: list[dict[str, Any]]) -> str:
+    """Render weekly digest content section (topic reports) as HTML."""
+    content = ""
+    base_url = _get_frontend_base_url()
+
+    for report in prepared_reports:
+        # Build search URL for this topic
+        topic_url = f"{base_url}/search?topics={report['topic']}"
+
+        content += f"""
+        <div class="topic-report">
+            <h2 class="topic-title">{report["topic_display"]}</h2>
+            <p class="topic-meta">
+                Week of {report["week_range"]} &bull; Based on {report["newsletter_count"]} newsletters
+            </p>
+
+            <div class="summary">
+                {_format_summary_paragraphs(report["summary"])}
+            </div>
+
+            <div class="matched-rules">
+                ✓ Matched your rule: {", ".join(report["matched_rules"])}
+            </div>
+
+            <p style="margin-top: 15px;">
+                <a href="{topic_url}" class="view-link">
+                    View all {report["topic_display"]} newsletters from this week →
+                </a>
+            </p>
+        </div>
+"""
+    return content
+
+
+def _build_digest_html(
+    prepared_data: list[dict[str, Any]],
+    digest_type: DigestType,
+    preferences_url: str,
+    unsubscribe_url: str,
+) -> str:
+    """
+    Build HTML email body for digest (daily or weekly).
+
+    Uses template-based rendering with type-specific content sections.
+
+    Args:
+        prepared_data: List of prepared data (newsletters or reports)
+        digest_type: Type of digest (DAILY or WEEKLY)
+        preferences_url: URL to preferences page
+        unsubscribe_url: One-click unsubscribe URL with signed token
+
+    Returns:
+        HTML string
+    """
+    # Determine header and content based on digest type
+    if digest_type == DigestType.DAILY:
+        title = "Daily Chicago Aldermen Newsletter Digest"
+        subtitle = "Chicago aldermen newsletters matching your interests"
+        content_section = _render_daily_content_html(prepared_data)
+    else:  # WEEKLY
+        title = "Weekly Topic Digest"
+        subtitle = "Chicago aldermen newsletters on topics you're following"
+        content_section = _render_weekly_content_html(prepared_data)
+
+    # Build HTML with shared template structure
+    html = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{title}</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 650px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }}
+        .container {{
+            background-color: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        .header {{
+            border-bottom: 3px solid #2563eb;
+            padding-bottom: 15px;
+            margin-bottom: 25px;
+        }}
+        h1 {{
+            margin: 0;
+            color: #1e40af;
+            font-size: 24px;
+        }}
+        .subtitle {{
+            color: #6b7280;
+            margin: 5px 0 0 0;
+            font-size: 14px;
+        }}
+        /* Daily digest styles */
+        .newsletter {{
+            border-left: 4px solid #e5e7eb;
+            padding: 15px;
+            margin-bottom: 20px;
+            background-color: #f9fafb;
+        }}
+        .newsletter-title {{
+            font-size: 18px;
+            font-weight: 600;
+            color: #1f2937;
+            margin: 0 0 8px 0;
+        }}
+        .newsletter-meta {{
+            color: #6b7280;
+            font-size: 13px;
+            margin-bottom: 10px;
+        }}
+        .newsletter-summary {{
+            margin: 10px 0;
+            color: #374151;
+        }}
+        .topics {{
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 10px 0;
+        }}
+        .topic {{
+            background-color: #dbeafe;
+            color: #1e40af;
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+        }}
+        .read-more {{
+            display: inline-block;
+            margin-top: 8px;
+            color: #2563eb;
+            text-decoration: none;
+            font-weight: 500;
+        }}
+        .read-more:hover {{
+            text-decoration: underline;
+        }}
+        /* Weekly digest styles */
+        .topic-report {{
+            border-left: 4px solid #10b981;
+            padding: 20px;
+            margin-bottom: 30px;
+            background-color: #f9fafb;
+        }}
+        .topic-title {{
+            font-size: 20px;
+            font-weight: 600;
+            color: #1f2937;
+            margin: 0 0 8px 0;
+        }}
+        .topic-meta {{
+            color: #6b7280;
+            font-size: 13px;
+            margin-bottom: 15px;
+        }}
+        .summary {{
+            margin: 15px 0;
+            color: #374151;
+        }}
+        .summary p {{
+            margin: 12px 0;
+        }}
+        .view-link {{
+            color: #2563eb;
+            text-decoration: none;
+            font-weight: 500;
+            font-size: 14px;
+        }}
+        .view-link:hover {{
+            text-decoration: underline;
+        }}
+        /* Shared styles */
+        .matched-rules {{
+            background-color: #f0fdf4;
+            border-left: 3px solid #10b981;
+            padding: 8px 12px;
+            margin: 10px 0;
+            font-size: 13px;
+            color: #065f46;
+        }}
+        .matched-rules strong {{
+            color: #047857;
+        }}
+        .footer {{
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e5e7eb;
+            font-size: 13px;
+            color: #6b7280;
+            text-align: center;
+        }}
+        .footer a {{
+            color: #2563eb;
+            text-decoration: none;
+        }}
+        .footer a:hover {{
+            text-decoration: underline;
+        }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>{title}</h1>
+            <p class="subtitle">{subtitle}</p>
+        </div>
+
+        {content_section}
+
         <div class="footer">
             <p>
-                You received this email because you have active notification rules.
-                <br>
                 <a href="{preferences_url}">Manage your notification preferences</a>
                 •
                 <a href="{unsubscribe_url}">Unsubscribe</a>
@@ -400,52 +526,97 @@ def _build_digest_html(
     return html
 
 
+def _render_daily_content_text(prepared_newsletters: list[dict[str, Any]]) -> str:
+    """Render daily digest content section (newsletters) as plain text."""
+    content = f"You have {len(prepared_newsletters)} newsletters to review:\n\n"
+
+    for i, newsletter in enumerate(prepared_newsletters, 1):
+        content += f"""{i}. {newsletter["title"]}
+From: {newsletter["source_name"]}{newsletter["ward_text"]}
+Date: {newsletter["date_formatted"]}
+"""
+
+        if newsletter["matched_rules"]:
+            rules_text = ", ".join(newsletter["matched_rules"])
+            content += f"✓ Matched your rules: {rules_text}\n"
+
+        if newsletter["summary"]:
+            content += f"\n{newsletter['summary']}\n"
+
+        if newsletter["topics"]:
+            content += f"\nTopics: {', '.join(newsletter['topics'][:5])}\n"
+
+        content += f"\nRead more: {newsletter['newsletter_url']}\n\n"
+        content += "-" * 60 + "\n\n"
+
+    return content
+
+
+def _render_weekly_content_text(prepared_reports: list[dict[str, Any]]) -> str:
+    """Render weekly digest content section (topic reports) as plain text."""
+    base_url = _get_frontend_base_url()
+    content = f"You have {len(prepared_reports)} topic reports this week:\n\n"
+    content += "=" * 70 + "\n\n"
+
+    for i, report in enumerate(prepared_reports, 1):
+        content += f"{i}. {report['topic_display']}\n"
+        content += f"Week of {report['week_range']}\n"
+        content += f"Based on {report['newsletter_count']} newsletters\n"
+
+        if report["matched_rules"]:
+            rules_text = ", ".join(report["matched_rules"])
+            content += f"✓ Matched your rule: {rules_text}\n"
+
+        content += "\n"
+        content += report["summary"]
+        content += "\n\n"
+
+        topic_url = f"{base_url}/search?topics={report['topic']}"
+        content += f"View all {report['topic_display']} newsletters from this week:\n"
+        content += f"{topic_url}\n\n"
+        content += "=" * 70 + "\n\n"
+
+    return content
+
+
 def _build_digest_text(
-    prepared_newsletters: list[dict[str, Any]],
+    prepared_data: list[dict[str, Any]],
+    digest_type: DigestType,
     preferences_url: str,
     unsubscribe_url: str,
 ) -> str:
     """
-    Build plain text email body for daily digest.
+    Build plain text email body for digest (daily or weekly).
+
+    Uses template-based rendering with type-specific content sections.
 
     Args:
-        prepared_newsletters: List of dicts with all newsletter data pre-extracted and formatted
+        prepared_data: List of prepared data (newsletters or reports)
+        digest_type: Type of digest (DAILY or WEEKLY)
         preferences_url: URL to preferences page
         unsubscribe_url: One-click unsubscribe URL with signed token
 
     Returns:
         Plain text string
     """
-    # Build plain text
-    text = f"""DAILY NEWSLETTER DIGEST
+    # Determine header and content based on digest type
+    if digest_type == DigestType.DAILY:
+        header = """DAILY NEWSLETTER DIGEST
 Chicago aldermen newsletters matching your interests
 
-You have {len(prepared_newsletters)} newsletters to review:
+"""
+        content_section = _render_daily_content_text(prepared_data)
+    else:  # WEEKLY
+        header = """WEEKLY TOPIC DIGEST
+Chicago aldermen newsletters on topics you're following
 
 """
+        content_section = _render_weekly_content_text(prepared_data)
 
-    # Add each newsletter
-    for i, newsletter in enumerate(prepared_newsletters, 1):
-        text += f"""{i}. {newsletter["title"]}
-From: {newsletter["source_name"]}{newsletter["ward_text"]}
-Date: {newsletter["date_formatted"]}
-"""
+    # Build text with shared template structure
+    text = header + content_section
 
-        # Add matched rules
-        if newsletter["matched_rules"]:
-            rules_text = ", ".join(newsletter["matched_rules"])
-            text += f"✓ Matched your rules: {rules_text}\n"
-
-        if newsletter["summary"]:
-            text += f"\n{newsletter['summary']}\n"
-
-        if newsletter["topics"]:
-            text += f"\nTopics: {', '.join(newsletter['topics'][:5])}\n"
-
-        text += f"\nRead more: {newsletter['newsletter_url']}\n\n"
-        text += "-" * 60 + "\n\n"
-
-    # Add footer
+    # Add shared footer
     text += f"""
 Manage your notification preferences: {preferences_url}
 Unsubscribe: {unsubscribe_url}
@@ -456,3 +627,193 @@ Built for Strong Towns Chicago - https://strongtownschicago.org
 """
 
     return text
+
+
+def send_weekly_digest(
+    user_id: str,
+    user_email: str,
+    notifications: list[dict[str, Any]],
+    preferences_url: str | None = None,
+) -> dict[str, Any]:
+    """
+    Send a weekly digest email with topic-based reports.
+
+    Wrapper around send_digest() for backward compatibility.
+
+    Args:
+        user_id: User's unique identifier
+        user_email: Recipient email address
+        notifications: List of notification records (report references)
+        preferences_url: URL to preferences page
+
+    Returns:
+        Dictionary with 'success' (bool), 'email_id' (str if success), 'error' (str if failed)
+    """
+    return send_digest(
+        user_id, user_email, notifications, DigestType.WEEKLY, preferences_url
+    )
+
+
+# ============================================================================
+# DATA PREPARATION FUNCTIONS
+# ============================================================================
+
+
+def _prepare_weekly_report_data(
+    notifications: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Extract and format weekly report data for email rendering.
+
+    Groups notifications by topic, fetches report summaries, formats data.
+
+    Args:
+        notifications: List of notification records from database
+                      (report data should be joined as 'weekly_topic_reports')
+
+    Returns:
+        List of dicts with topic, summary, newsletter_count, week_id, matched_rules
+    """
+    # Group by topic and collect rule names
+    reports_with_rules = {}
+
+    for notif in notifications:
+        # For weekly notifications, newsletter_id is actually report_id
+        report_data = notif.get("weekly_topic_reports")
+        if not report_data:
+            continue
+
+        topic = report_data.get("topic")
+        if not topic:
+            continue
+
+        # Get rule name
+        rule_data = notif.get("rule", {})
+        rule_name = (
+            rule_data.get("name", "Unknown Rule") if rule_data else "Unknown Rule"
+        )
+
+        # Group by topic
+        if topic not in reports_with_rules:
+            reports_with_rules[topic] = {
+                "report": report_data,
+                "matched_rules": [],
+            }
+
+        # Add rule name if not already in list
+        if rule_name not in reports_with_rules[topic]["matched_rules"]:
+            reports_with_rules[topic]["matched_rules"].append(rule_name)
+
+    # Sort by topic name
+    sorted_items = sorted(reports_with_rules.items(), key=lambda x: x[0])
+
+    # Extract and format all data
+    prepared_reports = []
+    for topic, item in sorted_items:
+        report = item["report"]
+
+        # Parse week_id to readable date range
+        week_id = report.get("week_id", "")
+        week_range = _format_week_range(week_id)
+
+        # Map topic to friendly name
+        topic_display = _format_topic_name(topic)
+
+        # Count newsletters
+        newsletter_ids = report.get("newsletter_ids", [])
+        newsletter_count = len(newsletter_ids) if newsletter_ids else 0
+
+        prepared_reports.append(
+            {
+                "topic": topic,
+                "topic_display": topic_display,
+                "summary": report.get("report_summary", ""),
+                "newsletter_count": newsletter_count,
+                "week_range": week_range,
+                "week_id": week_id,
+                "matched_rules": item["matched_rules"],
+            }
+        )
+
+    return prepared_reports
+
+
+def _format_week_range(week_id: str) -> str:
+    """
+    Convert ISO week ID (YYYY-WXX) to readable date range.
+
+    Args:
+        week_id: ISO week identifier (e.g., "2026-W05")
+
+    Returns:
+        Formatted string (e.g., "January 26 - February 1, 2026")
+    """
+    try:
+        year_str, week_str = week_id.split("-W")
+        year = int(year_str)
+        week = int(week_str)
+
+        # Calculate week start (Monday)
+        from datetime import datetime, timedelta
+
+        jan_4 = datetime(year, 1, 4)  # Always in week 1
+        week_1_monday = jan_4 - timedelta(days=jan_4.weekday())
+        week_start = week_1_monday + timedelta(weeks=week - 1)
+        week_end = week_start + timedelta(days=6)
+
+        # Format: "January 26 - February 1, 2026"
+        if week_start.month == week_end.month:
+            return f"{week_start.strftime('%B %d')} - {week_end.strftime('%d, %Y')}"
+        else:
+            return f"{week_start.strftime('%B %d')} - {week_end.strftime('%B %d, %Y')}"
+
+    except (ValueError, AttributeError):
+        return week_id
+
+
+def _format_topic_name(topic: str) -> str:
+    """
+    Convert topic identifier to friendly display name.
+
+    Args:
+        topic: Topic identifier (e.g., "bike_lanes")
+
+    Returns:
+        Formatted string (e.g., "Bike Lanes and Cycling Infrastructure")
+    """
+    topic_names = {
+        "4_flats_legalization": "4-Flats and Small-Scale Housing",
+        "missing_middle_housing": "Missing Middle Housing",
+        "accessory_dwelling_units": "Accessory Dwelling Units (ADUs)",
+        "single_stair_reform": "Single-Stair Building Reform",
+        "bike_lanes": "Bike Lanes and Cycling Infrastructure",
+        "street_redesign": "Street Redesign and Reconstruction",
+        "street_safety_or_traffic_calming": "Street Safety and Traffic Calming",
+        "transit_funding": "Public Transit Funding and Service",
+        "city_budget": "City Budget and Fiscal Policy",
+        "tax_policy": "Tax Policy and Revenue",
+        "zoning_or_development_meeting_or_approval": "Zoning and Development Approvals",
+        "city_charter": "City Charter and Governance Reform",
+    }
+    return topic_names.get(topic, topic.replace("_", " ").title())
+
+
+# Helper function for formatting summary paragraphs (used by weekly digest HTML)
+def _format_summary_paragraphs(summary: str) -> str:
+    """
+    Format summary text as HTML paragraphs.
+
+    Args:
+        summary: Plain text summary with paragraph breaks
+
+    Returns:
+        HTML with <p> tags
+    """
+    if not summary:
+        return ""
+
+    # Split on double newlines for paragraphs
+    paragraphs = [p.strip() for p in summary.split("\n\n") if p.strip()]
+
+    # Wrap each in <p> tags
+    return "\n".join(f"<p>{p}</p>" for p in paragraphs)

--- a/backend/notifications/email_sender.py
+++ b/backend/notifications/email_sender.py
@@ -571,8 +571,8 @@ def _render_weekly_content_text(prepared_reports: list[dict[str, Any]]) -> str:
         content += report["summary"]
         content += "\n\n"
 
-        topic_url = f"{base_url}/search?topics={report['topic']}"
-        content += f"View all {report['topic_display']} newsletters from this week:\n"
+        topic_url = f"{base_url}/search?q=&ward=&topics={report['topic']}"
+        content += f"View all {report['topic_display']} newsletters:\n"
         content += f"{topic_url}\n\n"
         content += "=" * 70 + "\n\n"
 
@@ -669,7 +669,7 @@ def _prepare_weekly_report_data(
 
     Args:
         notifications: List of notification records from database
-                      (report data should be joined as 'weekly_topic_reports')
+                      (report data should be joined as 'report')
 
     Returns:
         List of dicts with topic, summary, newsletter_count, week_id, matched_rules
@@ -678,8 +678,8 @@ def _prepare_weekly_report_data(
     reports_with_rules = {}
 
     for notif in notifications:
-        # For weekly notifications, newsletter_id is actually report_id
-        report_data = notif.get("weekly_topic_reports")
+        # For weekly notifications, report data is joined as "report"
+        report_data = notif.get("report")
         if not report_data:
             continue
 

--- a/backend/notifications/email_sender.py
+++ b/backend/notifications/email_sender.py
@@ -295,7 +295,7 @@ def _render_weekly_content_html(prepared_reports: list[dict[str, Any]]) -> str:
 
     for report in prepared_reports:
         # Build search URL for this topic
-        topic_url = f"{base_url}/search?topics={report['topic']}"
+        topic_url = f"{base_url}/search?topic={report['topic']}"
 
         content += f"""
         <div class="topic-report">
@@ -665,7 +665,7 @@ def _render_weekly_content_text(prepared_reports: list[dict[str, Any]]) -> str:
 
             content += "\n"
 
-        topic_url = f"{base_url}/search?q=&ward=&topics={report['topic']}"
+        topic_url = f"{base_url}/search?topic={report['topic']}"
         content += f"View all {report['topic_display']} newsletters:\n"
         content += f"{topic_url}\n\n"
         content += "=" * 70 + "\n\n"

--- a/backend/notifications/email_sender.py
+++ b/backend/notifications/email_sender.py
@@ -10,6 +10,7 @@ from typing import Any
 from datetime import datetime
 import resend
 from notifications.unsubscribe_tokens import generate_unsubscribe_token
+from shared.db import get_supabase_client
 
 
 class DigestType(Enum):
@@ -310,10 +311,51 @@ def _render_weekly_content_html(prepared_reports: list[dict[str, Any]]) -> str:
             <div class="matched-rules">
                 ✓ Matched your rule: {", ".join(report["matched_rules"])}
             </div>
+"""
 
+        # Add referenced newsletters section
+        if report.get("referenced_newsletters"):
+            content += """
+            <div class="referenced-newsletters">
+                <strong>Referenced newsletters:</strong>
+                <ul style="margin: 8px 0; padding-left: 20px;">
+"""
+            for nl in report["referenced_newsletters"]:
+                # Format date
+                try:
+                    date_obj = datetime.fromisoformat(
+                        nl["received_date"].replace("Z", "+00:00")
+                    )
+                    date_str = date_obj.strftime("%B %d, %Y")
+                except (ValueError, TypeError):
+                    date_str = nl["received_date"][:10]
+
+                # Format ward
+                ward_str = (
+                    f"Ward {nl['ward_number']}" if nl["ward_number"] else "Citywide"
+                )
+
+                # Build newsletter URL
+                nl_url = f"{base_url}/newsletter/{nl['id']}"
+
+                content += f"""
+                    <li style="margin: 4px 0;">
+                        <a href="{nl_url}" style="color: #2563eb; text-decoration: none;">
+                            {ward_str}: {nl["subject"]}
+                        </a>
+                        <span style="color: #6b7280; font-size: 13px;"> &bull; {date_str}</span>
+                    </li>
+"""
+
+            content += """
+                </ul>
+            </div>
+"""
+
+        content += f"""
             <p style="margin-top: 15px;">
                 <a href="{topic_url}" class="view-link">
-                    View all {report["topic_display"]} newsletters from this week →
+                    View all newsletters on {report["topic_display"]} →
                 </a>
             </p>
         </div>
@@ -482,6 +524,32 @@ def _build_digest_html(
         .matched-rules strong {{
             color: #047857;
         }}
+        .referenced-newsletters {{
+            margin: 15px 0;
+            padding: 12px;
+            background-color: #f9fafb;
+            border-left: 3px solid #e5e7eb;
+            font-size: 13px;
+        }}
+        .referenced-newsletters strong {{
+            color: #374151;
+        }}
+        .referenced-newsletters ul {{
+            list-style: none;
+            margin: 8px 0;
+            padding: 0;
+        }}
+        .referenced-newsletters li {{
+            margin: 6px 0;
+            padding-left: 0;
+        }}
+        .referenced-newsletters a {{
+            color: #2563eb;
+            text-decoration: none;
+        }}
+        .referenced-newsletters a:hover {{
+            text-decoration: underline;
+        }}
         .footer {{
             margin-top: 30px;
             padding-top: 20px;
@@ -571,6 +639,32 @@ def _render_weekly_content_text(prepared_reports: list[dict[str, Any]]) -> str:
         content += report["summary"]
         content += "\n\n"
 
+        # Add referenced newsletters
+        if report.get("referenced_newsletters"):
+            content += "Referenced newsletters:\n"
+            for nl in report["referenced_newsletters"]:
+                # Format date
+                try:
+                    date_obj = datetime.fromisoformat(
+                        nl["received_date"].replace("Z", "+00:00")
+                    )
+                    date_str = date_obj.strftime("%B %d, %Y")
+                except (ValueError, TypeError):
+                    date_str = nl["received_date"][:10]
+
+                # Format ward
+                ward_str = (
+                    f"Ward {nl['ward_number']}" if nl["ward_number"] else "Citywide"
+                )
+
+                # Build newsletter URL
+                nl_url = f"{base_url}/newsletter/{nl['id']}"
+
+                content += f"  • {ward_str}: {nl['subject']} ({date_str})\n"
+                content += f"    {nl_url}\n"
+
+            content += "\n"
+
         topic_url = f"{base_url}/search?q=&ward=&topics={report['topic']}"
         content += f"View all {report['topic_display']} newsletters:\n"
         content += f"{topic_url}\n\n"
@@ -659,6 +753,60 @@ def send_weekly_digest(
 # ============================================================================
 
 
+def _fetch_newsletter_details(newsletter_ids: list[str]) -> list[dict[str, Any]]:
+    """
+    Fetch newsletter details for referenced newsletters.
+
+    Args:
+        newsletter_ids: List of newsletter UUIDs
+
+    Returns:
+        List of dicts with id, subject, received_date, ward_number, sorted by ward
+    """
+    if not newsletter_ids:
+        return []
+
+    supabase = get_supabase_client()
+
+    try:
+        response = (
+            supabase.table("newsletters")
+            .select("id, subject, received_date, source:sources(ward_number)")
+            .in_("id", newsletter_ids)
+            .execute()
+        )
+
+        newsletters = []
+        for nl in response.data:
+            nl_dict = dict(nl)  # type: ignore
+            source_data = nl_dict.get("source")
+            ward_number = (
+                source_data.get("ward_number")
+                if source_data and isinstance(source_data, dict)
+                else None
+            )
+
+            newsletters.append(
+                {
+                    "id": str(nl_dict["id"]),
+                    "subject": str(nl_dict["subject"]),
+                    "received_date": str(nl_dict["received_date"]),
+                    "ward_number": ward_number,
+                }
+            )
+
+        # Sort by ward number (put None/citywide last)
+        newsletters.sort(
+            key=lambda x: (x["ward_number"] is None, x["ward_number"] or 999)
+        )
+
+        return newsletters
+
+    except Exception as e:
+        print(f"Warning: Failed to fetch newsletter details: {e}")
+        return []
+
+
 def _prepare_weekly_report_data(
     notifications: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -723,6 +871,9 @@ def _prepare_weekly_report_data(
         newsletter_ids = report.get("newsletter_ids", [])
         newsletter_count = len(newsletter_ids) if newsletter_ids else 0
 
+        # Fetch newsletter details for referenced newsletters
+        referenced_newsletters = _fetch_newsletter_details(newsletter_ids)
+
         prepared_reports.append(
             {
                 "topic": topic,
@@ -732,6 +883,7 @@ def _prepare_weekly_report_data(
                 "week_range": week_range,
                 "week_id": week_id,
                 "matched_rules": item["matched_rules"],
+                "referenced_newsletters": referenced_newsletters,
             }
         )
 

--- a/backend/notifications/process_notification_queue.py
+++ b/backend/notifications/process_notification_queue.py
@@ -179,7 +179,9 @@ def process_digests(
         if not preferences.get("enabled", True):
             print("  ⚠️  Notifications disabled for user, skipping")
             stats["skipped"] += 1
-            _mark_notifications_skipped(supabase, notifications)
+            _mark_notifications_failed(
+                supabase, notifications, "User notifications disabled"
+            )
             continue
 
         # Send digest email (type-specific sender)
@@ -216,6 +218,28 @@ def process_digests(
                     }
                 ).execute()
 
+            elif result.get("error") == "Empty digest content":
+                print(f"  ⚠ Skipped user {user_id}: Empty digest content")
+                stats["skipped"] += 1
+
+                # Update notification queue with skip reason
+                _mark_notifications_failed(supabase, notifications, result["error"])
+
+                # Record skip in history (as failure, but with specific reason)
+                content_ids = _extract_content_ids(notifications)
+                rule_ids = list(set([n["rule_id"] for n in notifications]))
+                supabase.table("notification_history").insert(
+                    {
+                        "user_id": user_id,
+                        "newsletter_ids": content_ids,
+                        "rule_ids": rule_ids,
+                        "digest_batch_id": batch_id,
+                        "delivery_type": config.delivery_type,
+                        "success": False,
+                        "error_message": result["error"],
+                    }
+                ).execute()
+
             else:
                 error_msg = cast(str, result.get("error", "Unknown error"))
                 print(f"  ✗ Failed to send to user {user_id}: {error_msg}")
@@ -236,10 +260,7 @@ def process_digests(
                 print(f"    Error details logged to: {error_file}")
 
                 # Update notification queue with error
-                notification_ids = [n["id"] for n in notifications]
-                supabase.table("notification_queue").update(
-                    {"status": "failed", "error_message": error_msg}
-                ).in_("id", notification_ids).execute()
+                _mark_notifications_failed(supabase, notifications, error_msg)
 
                 # Record failure in history
                 rule_ids = list(set([n["rule_id"] for n in notifications]))
@@ -313,13 +334,13 @@ def _extract_content_ids(notifications: list[dict[str, Any]]) -> list[str]:
     return list(set(content_ids))
 
 
-def _mark_notifications_skipped(
-    supabase: Any, notifications: list[dict[str, Any]]
+def _mark_notifications_failed(
+    supabase: Any, notifications: list[dict[str, Any]], error_message: str
 ) -> None:
-    """Mark notifications as failed (user has notifications disabled)."""
+    """Mark notifications as failed with a specific reason."""
     notification_ids = [n["id"] for n in notifications]
     supabase.table("notification_queue").update(
-        {"status": "failed", "error_message": "User notifications disabled"}
+        {"status": "failed", "error_message": error_message}
     ).in_("id", notification_ids).execute()
 
 

--- a/backend/notifications/process_notification_queue.py
+++ b/backend/notifications/process_notification_queue.py
@@ -65,8 +65,8 @@ def _fetch_weekly_notifications(batch_id: str) -> dict[str, list[dict[str, Any]]
         response = (
             supabase.table("notification_queue")
             .select(
-                "id, user_id, newsletter_id, rule_id, "
-                "weekly_topic_reports:newsletter_id(id, topic, week_id, report_summary, newsletter_ids), "
+                "id, user_id, report_id, rule_id, "
+                "report:weekly_topic_reports(id, topic, week_id, report_summary, newsletter_ids), "
                 "rule:notification_rules(name)"
             )
             .eq("status", "pending")
@@ -200,13 +200,14 @@ def process_digests(
                 ).in_("id", notification_ids).execute()
 
                 # Record in history
-                newsletter_ids = list(set([n["newsletter_id"] for n in notifications]))
+                # Extract content IDs (works for both newsletter_id and report_id)
+                content_ids = _extract_content_ids(notifications)
                 rule_ids = list(set([n["rule_id"] for n in notifications]))
 
                 supabase.table("notification_history").insert(
                     {
                         "user_id": user_id,
-                        "newsletter_ids": newsletter_ids,
+                        "newsletter_ids": content_ids,  # Stores both newsletter and report IDs
                         "rule_ids": rule_ids,
                         "digest_batch_id": batch_id,
                         "delivery_type": config.delivery_type,
@@ -221,6 +222,7 @@ def process_digests(
                 stats["failed"] += 1
 
                 # Log error to file
+                content_ids = _extract_content_ids(notifications)
                 error_file = log_notification_error(
                     error_type="sending",
                     error_message=error_msg,
@@ -228,7 +230,7 @@ def process_digests(
                         "user_id": user_id,
                         "batch_id": batch_id,
                         "notification_count": len(notifications),
-                        "newsletter_ids": [n["newsletter_id"] for n in notifications],
+                        "content_ids": content_ids,  # Works for both newsletter and report IDs
                     },
                 )
                 print(f"    Error details logged to: {error_file}")
@@ -240,13 +242,12 @@ def process_digests(
                 ).in_("id", notification_ids).execute()
 
                 # Record failure in history
-                newsletter_ids = list(set([n["newsletter_id"] for n in notifications]))
                 rule_ids = list(set([n["rule_id"] for n in notifications]))
 
                 supabase.table("notification_history").insert(
                     {
                         "user_id": user_id,
-                        "newsletter_ids": newsletter_ids,
+                        "newsletter_ids": content_ids,  # Stores both newsletter and report IDs
                         "rule_ids": rule_ids,
                         "digest_batch_id": batch_id,
                         "delivery_type": config.delivery_type,
@@ -287,6 +288,29 @@ def process_daily_digests(
         Dictionary with stats: sent, failed, skipped
     """
     return process_digests(DigestType.DAILY, batch_id, dry_run)
+
+
+def _extract_content_ids(notifications: list[dict[str, Any]]) -> list[str]:
+    """
+    Extract content IDs from notifications (either newsletter_id or report_id).
+
+    For daily notifications, extracts newsletter_id.
+    For weekly notifications, extracts report_id.
+
+    Args:
+        notifications: List of notification dictionaries
+
+    Returns:
+        List of unique content IDs (UUIDs as strings)
+    """
+    content_ids = []
+    for n in notifications:
+        # Weekly notifications have report_id, daily have newsletter_id
+        if "report_id" in n and n["report_id"] is not None:
+            content_ids.append(n["report_id"])
+        elif "newsletter_id" in n and n["newsletter_id"] is not None:
+            content_ids.append(n["newsletter_id"])
+    return list(set(content_ids))
 
 
 def _mark_notifications_skipped(

--- a/backend/notifications/process_notification_queue.py
+++ b/backend/notifications/process_notification_queue.py
@@ -16,40 +16,131 @@ import argparse
 import time
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
-from typing import Any, cast
+from typing import Any, cast, Callable
+from dataclasses import dataclass
 from shared.db import get_supabase_client
 from notifications.rule_matcher import get_pending_notifications_by_user
-from notifications.email_sender import send_daily_digest
+from notifications.email_sender import send_digest, DigestType
 from notifications.error_logger import log_notification_error
 
 
-def process_daily_digests(
-    batch_id: str | None = None, dry_run: bool = False
+@dataclass
+class DigestConfig:
+    """Configuration for digest processing by type."""
+
+    digest_type: DigestType
+    notification_type: str  # DB filter value
+    delivery_type: str  # History record value
+    batch_id_calculator: Callable[[], str]  # Function to calculate default batch_id
+    fetch_notifications: Callable[
+        [str], dict[str, list[dict[str, Any]]]
+    ]  # Fetch function
+
+
+def _calculate_daily_batch_id() -> str:
+    """Calculate default batch ID for daily digests (yesterday in Chicago time)."""
+    chicago_tz = ZoneInfo("America/Chicago")
+    yesterday = datetime.now(chicago_tz).date() - timedelta(days=1)
+    return yesterday.isoformat()
+
+
+def _calculate_weekly_batch_id() -> str:
+    """Calculate default batch ID for weekly digests (previous week)."""
+    chicago_tz = ZoneInfo("America/Chicago")
+    last_week = datetime.now(chicago_tz) - timedelta(days=7)
+    year, week, _ = last_week.isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+def _fetch_daily_notifications(batch_id: str) -> dict[str, list[dict[str, Any]]]:
+    """Fetch pending daily notifications grouped by user."""
+    return get_pending_notifications_by_user(batch_id)
+
+
+def _fetch_weekly_notifications(batch_id: str) -> dict[str, list[dict[str, Any]]]:
+    """Fetch pending weekly notifications grouped by user."""
+    supabase = get_supabase_client()
+
+    try:
+        response = (
+            supabase.table("notification_queue")
+            .select(
+                "id, user_id, newsletter_id, rule_id, "
+                "weekly_topic_reports:newsletter_id(id, topic, week_id, report_summary, newsletter_ids), "
+                "rule:notification_rules(name)"
+            )
+            .eq("status", "pending")
+            .eq("notification_type", "weekly")
+            .eq("digest_batch_id", batch_id)
+            .execute()
+        )
+
+        # Group by user
+        notifications_by_user: dict[str, list[dict[str, Any]]] = {}
+        for notif in response.data:
+            notif_dict = dict(notif)  # type: ignore
+            user_id = str(notif_dict["user_id"])
+            if user_id not in notifications_by_user:
+                notifications_by_user[user_id] = []
+            notifications_by_user[user_id].append(notif_dict)
+
+        return notifications_by_user
+
+    except Exception as e:
+        print(f"Error fetching weekly notifications: {e}")
+        return {}
+
+
+# Digest type configurations
+DIGEST_CONFIGS = {
+    DigestType.DAILY: DigestConfig(
+        digest_type=DigestType.DAILY,
+        notification_type="daily",
+        delivery_type="daily_digest",
+        batch_id_calculator=_calculate_daily_batch_id,
+        fetch_notifications=_fetch_daily_notifications,
+    ),
+    DigestType.WEEKLY: DigestConfig(
+        digest_type=DigestType.WEEKLY,
+        notification_type="weekly",
+        delivery_type="weekly_digest",
+        batch_id_calculator=_calculate_weekly_batch_id,
+        fetch_notifications=_fetch_weekly_notifications,
+    ),
+}
+
+
+def process_digests(
+    digest_type: DigestType, batch_id: str | None = None, dry_run: bool = False
 ) -> dict[str, int]:
     """
-    Process daily digest notifications.
+    Process digest notifications (daily or weekly).
 
-    Groups all pending notifications by user and sends ONE email per user
-    with all matched newsletters from the specified batch (default: yesterday in Chicago timezone).
+    Generic digest processor that handles both daily newsletter digests and
+    weekly topic report digests using type-specific configuration.
 
     Args:
-        batch_id: Digest batch ID (YYYY-MM-DD format). Defaults to yesterday (Chicago time).
+        digest_type: Type of digest to process (DigestType.DAILY or DigestType.WEEKLY)
+        batch_id: Digest batch ID. Format depends on type:
+                  - Daily: YYYY-MM-DD (defaults to yesterday in Chicago time)
+                  - Weekly: YYYY-WXX (defaults to previous week)
         dry_run: If True, don't actually send emails (for testing)
 
     Returns:
         Dictionary with stats: sent, failed, skipped
     """
-    # Default to yesterday (Chicago timezone) if no batch ID specified
-    # Workflow runs at 13:35 UTC (~7:35-8:35am Central) sending previous day's batch
+    # Get configuration for this digest type
+    config = DIGEST_CONFIGS[digest_type]
+
+    # Calculate default batch_id if not provided
     if not batch_id:
-        chicago_tz = ZoneInfo("America/Chicago")
-        yesterday = datetime.now(chicago_tz).date() - timedelta(days=1)
-        batch_id = yesterday.isoformat()
+        batch_id = config.batch_id_calculator()
 
-    print(f"Processing daily digest for batch: {batch_id}")
+    digest_name = "daily" if digest_type == DigestType.DAILY else "weekly"
+    print(f"Processing {digest_name} digest for batch: {batch_id}")
 
-    # Get pending notifications grouped by user
-    notifications_by_user = get_pending_notifications_by_user(batch_id)
+    # Fetch pending notifications grouped by user (type-specific)
+    notifications_by_user = config.fetch_notifications(batch_id)
 
     if not notifications_by_user:
         print("No pending notifications to process.")
@@ -91,12 +182,12 @@ def process_daily_digests(
             _mark_notifications_skipped(supabase, notifications)
             continue
 
-        # Send digest email
+        # Send digest email (type-specific sender)
         if dry_run:
-            print(f"  [DRY RUN] Would send digest to user {user_id}")
+            print(f"  [DRY RUN] Would send {digest_name} digest to {user_email}")
             stats["sent"] += 1
         else:
-            result = send_daily_digest(user_id, user_email, notifications)
+            result = send_digest(user_id, user_email, notifications, config.digest_type)
 
             if result["success"]:
                 print(f"  ✓ Sent digest to user {user_id}")
@@ -118,7 +209,7 @@ def process_daily_digests(
                         "newsletter_ids": newsletter_ids,
                         "rule_ids": rule_ids,
                         "digest_batch_id": batch_id,
-                        "delivery_type": "daily_digest",
+                        "delivery_type": config.delivery_type,
                         "success": True,
                         "resend_email_id": result.get("email_id"),
                     }
@@ -158,7 +249,7 @@ def process_daily_digests(
                         "newsletter_ids": newsletter_ids,
                         "rule_ids": rule_ids,
                         "digest_batch_id": batch_id,
-                        "delivery_type": "daily_digest",
+                        "delivery_type": config.delivery_type,
                         "success": False,
                         "error_message": error_msg,
                     }
@@ -169,7 +260,7 @@ def process_daily_digests(
 
     # Print summary
     print(f"\n{'=' * 60}")
-    print("Daily Digest Processing Complete")
+    print(f"{digest_name.title()} Digest Processing Complete")
     print(f"{'=' * 60}")
     print(f"Batch ID: {batch_id}")
     print(f"Sent:     {stats['sent']}")
@@ -180,6 +271,24 @@ def process_daily_digests(
     return stats
 
 
+def process_daily_digests(
+    batch_id: str | None = None, dry_run: bool = False
+) -> dict[str, int]:
+    """
+    Process daily digest notifications.
+
+    Wrapper around process_digests() for backward compatibility and CLI convenience.
+
+    Args:
+        batch_id: Digest batch ID (YYYY-MM-DD format). Defaults to yesterday (Chicago time).
+        dry_run: If True, don't actually send emails (for testing)
+
+    Returns:
+        Dictionary with stats: sent, failed, skipped
+    """
+    return process_digests(DigestType.DAILY, batch_id, dry_run)
+
+
 def _mark_notifications_skipped(
     supabase: Any, notifications: list[dict[str, Any]]
 ) -> None:
@@ -188,6 +297,24 @@ def _mark_notifications_skipped(
     supabase.table("notification_queue").update(
         {"status": "failed", "error_message": "User notifications disabled"}
     ).in_("id", notification_ids).execute()
+
+
+def process_weekly_digests(
+    batch_id: str | None = None, dry_run: bool = False
+) -> dict[str, int]:
+    """
+    Process weekly digest notifications.
+
+    Wrapper around process_digests() for backward compatibility and CLI convenience.
+
+    Args:
+        batch_id: Week identifier (YYYY-WXX format). Defaults to previous week.
+        dry_run: If True, don't actually send emails (for testing)
+
+    Returns:
+        Dictionary with stats: sent, failed, skipped
+    """
+    return process_digests(DigestType.WEEKLY, batch_id, dry_run)
 
 
 def main() -> None:
@@ -201,9 +328,13 @@ def main() -> None:
     )
 
     parser.add_argument(
+        "--weekly-digest", action="store_true", help="Send weekly digest emails"
+    )
+
+    parser.add_argument(
         "--batch-id",
         type=str,
-        help="Specific batch ID to process (YYYY-MM-DD format, defaults to yesterday in Chicago timezone)",
+        help="Specific batch ID to process (YYYY-MM-DD for daily, YYYY-WXX for weekly)",
     )
 
     parser.add_argument(
@@ -214,11 +345,13 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if not args.daily_digest:
-        parser.error("Must specify --daily-digest")
+    if not args.daily_digest and not args.weekly_digest:
+        parser.error("Must specify --daily-digest or --weekly-digest")
 
     if args.daily_digest:
         process_daily_digests(batch_id=args.batch_id, dry_run=args.dry_run)
+    elif args.weekly_digest:
+        process_weekly_digests(batch_id=args.batch_id, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/backend/notifications/rule_matcher.py
+++ b/backend/notifications/rule_matcher.py
@@ -36,9 +36,10 @@ def match_newsletter_to_rules(
         response = (
             supabase.table("notification_rules")
             .select(
-                "id, user_id, name, topics, search_term, min_relevance_score, source_ids, ward_numbers"
+                "id, user_id, name, topics, search_term, min_relevance_score, source_ids, ward_numbers, delivery_frequency"
             )
             .eq("is_active", True)
+            .eq("delivery_frequency", "daily")
             .execute()
         )
 

--- a/backend/notifications/weekly_notification_queue.py
+++ b/backend/notifications/weekly_notification_queue.py
@@ -164,7 +164,7 @@ def queue_weekly_notifications(week_id: str) -> dict[str, int]:
                     supabase.table("notification_queue").insert(
                         {
                             "user_id": user_id,
-                            "newsletter_id": report_id,  # Store report_id here
+                            "report_id": report_id,  # Store in dedicated report_id column
                             "rule_id": rule_id,
                             "status": "pending",
                             "digest_batch_id": week_id,

--- a/backend/notifications/weekly_notification_queue.py
+++ b/backend/notifications/weekly_notification_queue.py
@@ -1,0 +1,234 @@
+"""
+Weekly notification queuing logic.
+
+Queues notifications for weekly topic reports based on user notification rules.
+Designed to run after weekly report generation is complete.
+
+Usage:
+    from notifications.weekly_notification_queue import queue_weekly_notifications
+
+    stats = queue_weekly_notifications("2026-W05")
+    print(f"Queued {stats['queued']} notifications for {stats['users']} users")
+"""
+
+from typing import Any
+
+from shared.db import get_supabase_client
+
+
+def get_users_with_weekly_rules() -> dict[str, list[dict[str, Any]]]:
+    """
+    Get all users with active weekly notification rules.
+
+    Returns:
+        Dictionary mapping user_id to list of their active weekly rules
+        Example: {"user-uuid-1": [{"id": "rule-uuid-1", "topics": ["bike_lanes"], ...}], ...}
+    """
+    supabase = get_supabase_client()
+
+    try:
+        # Query active weekly rules
+        response = (
+            supabase.table("notification_rules")
+            .select("id, user_id, topics")
+            .eq("is_active", True)
+            .eq("delivery_frequency", "weekly")
+            .execute()
+        )
+
+        # Group rules by user_id
+        users_rules: dict[str, list[dict[str, Any]]] = {}
+        for rule in response.data:
+            rule_dict = dict(rule)  # type: ignore
+            user_id = str(rule_dict["user_id"])
+            if user_id not in users_rules:
+                users_rules[user_id] = []
+            users_rules[user_id].append(rule_dict)
+
+        # Filter out users with notifications disabled
+        # Query user_profiles to check notification_preferences
+        if users_rules:
+            profiles_response = (
+                supabase.table("user_profiles")
+                .select("id, notification_preferences")
+                .in_("id", list(users_rules.keys()))
+                .execute()
+            )
+
+            # Build set of users with notifications enabled
+            enabled_users = set()
+            for profile in profiles_response.data:
+                profile_dict = dict(profile)  # type: ignore
+                prefs = profile_dict.get("notification_preferences", {})
+                if isinstance(prefs, dict) and prefs.get("enabled", True):
+                    enabled_users.add(str(profile_dict["id"]))
+
+            # Filter to only enabled users
+            users_rules = {
+                uid: rules for uid, rules in users_rules.items() if uid in enabled_users
+            }
+
+        return users_rules
+
+    except Exception as e:
+        print(f"⚠ Error querying weekly rules: {e}")
+        return {}
+
+
+def queue_weekly_notifications(week_id: str) -> dict[str, int]:
+    """
+    Queue weekly notifications based on generated reports and user rules.
+
+    Workflow:
+    1. Fetch all active weekly notification rules grouped by user
+    2. For each user:
+       a. Get their subscribed topics (from rules)
+       b. Fetch generated reports for those topics + week
+       c. For each matching report, queue notification:
+          - user_id, report_id (stored in newsletter_id), rule_id
+          - status: pending
+          - digest_batch_id: week_id
+          - notification_type: weekly
+    3. Return stats (queued, skipped, users)
+
+    Args:
+        week_id: Week identifier (YYYY-WXX)
+
+    Returns:
+        Dictionary with stats: {queued, skipped, users}
+    """
+    supabase = get_supabase_client()
+
+    print(f"\n{'=' * 60}")
+    print(f"Weekly Notification Queuing - Week {week_id}")
+    print(f"{'=' * 60}\n")
+
+    # Get users with active weekly rules
+    print("→ Querying users with weekly rules...")
+    users_rules = get_users_with_weekly_rules()
+
+    if not users_rules:
+        print("ℹ No users with active weekly rules found")
+        return {"queued": 0, "skipped": 0, "users": 0}
+
+    print(f"✓ Found {len(users_rules)} users with weekly rules\n")
+
+    # Fetch all generated reports for this week
+    print(f"→ Fetching generated reports for week {week_id}...")
+    try:
+        reports_response = (
+            supabase.table("weekly_topic_reports")
+            .select("id, topic, week_id")
+            .eq("week_id", week_id)
+            .execute()
+        )
+
+        # Build topic -> report_id mapping
+        topic_to_report: dict[str, str] = {}
+        for report in reports_response.data:
+            report_dict = dict(report)  # type: ignore
+            topic_to_report[str(report_dict["topic"])] = str(report_dict["id"])
+
+        print(
+            f"✓ Found {len(topic_to_report)} reports: {', '.join(topic_to_report.keys())}\n"
+        )
+
+    except Exception as e:
+        print(f"✗ Error fetching reports: {e}")
+        return {"queued": 0, "skipped": 0, "users": 0}
+
+    # Queue notifications for each user
+    stats = {"queued": 0, "skipped": 0, "users": 0}
+
+    for user_id, rules in users_rules.items():
+        user_queued = 0
+
+        for rule in rules:
+            rule_id = str(rule["id"])
+            topics = rule.get("topics", [])
+
+            if not isinstance(topics, list):
+                continue
+
+            # For each topic in the rule, check if report exists
+            for topic in topics:
+                if topic not in topic_to_report:
+                    # No report for this topic this week
+                    stats["skipped"] += 1
+                    continue
+
+                report_id = topic_to_report[topic]
+
+                # Queue notification
+                try:
+                    supabase.table("notification_queue").insert(
+                        {
+                            "user_id": user_id,
+                            "newsletter_id": report_id,  # Store report_id here
+                            "rule_id": rule_id,
+                            "status": "pending",
+                            "digest_batch_id": week_id,
+                            "notification_type": "weekly",
+                        }
+                    ).execute()
+
+                    stats["queued"] += 1
+                    user_queued += 1
+
+                except Exception:
+                    # Likely unique constraint violation (already queued)
+                    # This is fine - just skip
+                    stats["skipped"] += 1
+                    continue
+
+        if user_queued > 0:
+            stats["users"] += 1
+            print(f"  ✓ Queued {user_queued} notifications for user {user_id[:8]}...")
+
+    # Summary
+    print(f"\n{'=' * 60}")
+    print("Summary:")
+    print(f"  Queued:  {stats['queued']} notifications")
+    print(f"  Skipped: {stats['skipped']}")
+    print(f"  Users:   {stats['users']}")
+    print(f"{'=' * 60}\n")
+
+    return stats
+
+
+def main() -> None:
+    """CLI entry point for testing."""
+    import argparse
+    from datetime import datetime, timedelta
+    from zoneinfo import ZoneInfo
+
+    parser = argparse.ArgumentParser(
+        description="Queue weekly notifications for generated reports"
+    )
+
+    parser.add_argument(
+        "--week-id",
+        type=str,
+        help="Week ID to process (YYYY-WXX format). Defaults to previous week.",
+    )
+
+    args = parser.parse_args()
+
+    # Default to previous week
+    if args.week_id:
+        week_id = args.week_id
+    else:
+        chicago_tz = ZoneInfo("America/Chicago")
+        last_week = datetime.now(chicago_tz) - timedelta(days=7)
+        year, week, _ = last_week.isocalendar()
+        week_id = f"{year}-W{week:02d}"
+
+    stats = queue_weekly_notifications(week_id)
+
+    # Exit with non-zero if no notifications queued
+    if stats["queued"] == 0:
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/processing/llm_processor.py
+++ b/backend/processing/llm_processor.py
@@ -13,6 +13,7 @@ step building on the previous ones for better accuracy.
 from ollama import Client
 from pydantic import BaseModel, Field
 import time
+import json
 from datetime import datetime
 
 # LLM processing limits
@@ -62,10 +63,35 @@ class RelevanceScore(BaseModel):
 ollama_client = Client(timeout=240.0)
 
 
+def extract_json(text: str) -> str:
+    """
+    Extract JSON object from LLM response text.
+
+    Handles cases where the LLM wraps JSON in markdown blocks or adds
+    preamble/postamble text. Returns the substring between the first
+    '{' and the last '}'.
+    """
+    text = text.strip()
+
+    # Try to find JSON block in markdown
+    if "```json" in text:
+        text = text.split("```json")[1].split("```")[0].strip()
+    elif "```" in text:
+        text = text.split("```")[1].split("```")[0].strip()
+
+    # Find the outermost curly braces to isolate the JSON object
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1:
+        text = text[start : end + 1]
+
+    return text
+
+
 def call_llm(
     model: str,
     prompt: str,
-    schema: dict[str, object],
+    schema: dict[str, object] | None = None,
     temperature: float = 0,
     max_retries: int = MAX_LLM_RETRIES,
 ) -> str:
@@ -73,39 +99,56 @@ def call_llm(
     Call Ollama LLM with structured output validation and exponential backoff retry logic.
 
     Uses the global ollama_client with 240s timeout. Retries with exponential backoff (1s, 2s, 4s)
-    on failure. On the third attempt, truncates prompt to RETRY_TRUNCATE_MODERATE chars. On the
-    fourth attempt, truncates to RETRY_TRUNCATE_AGGRESSIVE chars. Validates that responses are
-    non-empty before returning.
+    on failure. On the third attempt, truncates prompt to RETRY_TRUNCATE_THRESHOLD chars.
+    Validates that responses are non-empty before returning.
+
+    Handles model-specific limitations for structured output (e.g., gpt-oss) by
+    automatically switching to prompt-based JSON extraction when the native 'format'
+    parameter is known to fail.
 
     Args:
         model: Ollama model name (e.g., "gpt-oss:20b")
         prompt: Prompt text to send to the LLM
-        schema: Pydantic model JSON schema for structured output format
+        schema: Optional Pydantic model JSON schema for structured output format
         temperature: Sampling temperature (0 = deterministic, higher = more random)
         max_retries: Maximum retry attempts on failure (default: MAX_LLM_RETRIES)
 
     Returns:
-        JSON string response from LLM
+        JSON string response from LLM (or raw text if no schema provided)
 
     Raises:
         Exception: If all retry attempts fail or LLM returns empty response
     """
     original_prompt = prompt
 
+    # gpt-oss models can fail with "failed to load model vocabulary required for format"
+    # when using Ollama's native 'format' parameter. We handle this by moving the
+    # schema into the prompt and manually extracting the JSON from the raw response.
+    # https://github.com/ollama/ollama/issues/11691
+    use_native_format = schema is not None and not model.startswith("gpt-oss")
+
+    if schema and not use_native_format:
+        prompt += f"\n\nRespond with valid JSON matching this schema:\n{json.dumps(schema, indent=2)}"
+
     for attempt in range(max_retries):
         try:
             # Truncate prompt on later attempts to avoid token limit issues
             if attempt == 2:  # Third attempt
                 if len(original_prompt) > RETRY_TRUNCATE_THRESHOLD:
-                    prompt = original_prompt[:RETRY_TRUNCATE_THRESHOLD]
+                    prompt_base = original_prompt[:RETRY_TRUNCATE_THRESHOLD]
+                    if schema and not use_native_format:
+                        prompt = f"{prompt_base}\n\nRespond with valid JSON matching this schema:\n{json.dumps(schema, indent=2)}"
+                    else:
+                        prompt = prompt_base
+
                     print(
-                        f"  ⚠ Truncating prompt: {len(original_prompt)} → {RETRY_TRUNCATE_THRESHOLD} chars"
+                        f"  ⚠ Truncating prompt: {len(original_prompt)} → {len(prompt)} chars"
                     )
 
             response = ollama_client.chat(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],
-                format=schema,
+                format=schema if use_native_format else None,
                 options={
                     "temperature": temperature,
                 },
@@ -115,6 +158,10 @@ def call_llm(
             # Validate it's not empty
             if not content or content.strip() == "":
                 raise ValueError("LLM returned empty response")
+
+            # If we manually requested JSON via the prompt, extract it from the response
+            if schema and not use_native_format:
+                content = extract_json(content)
 
             return content
 

--- a/backend/processing/llm_processor.py
+++ b/backend/processing/llm_processor.py
@@ -314,7 +314,7 @@ Newsletter:
         return None
 
 
-def process_with_ollama(
+def extract_newsletter_metadata(
     newsletter: dict[str, str],
     model: str = "gpt-oss:20b",
     max_chars: int = MAX_NEWSLETTER_CHARS,

--- a/backend/processing/llm_processor.py
+++ b/backend/processing/llm_processor.py
@@ -18,10 +18,7 @@ from datetime import datetime
 
 # LLM processing limits
 MAX_NEWSLETTER_CHARS = 100000  # Maximum newsletter content length before truncation
-MAX_LLM_RETRIES = 3  # Maximum retry attempts for failed LLM calls
-
-# Retry truncation limits for prompts that fail due to length/token issues
-RETRY_TRUNCATE_THRESHOLD = 50000  # Third attempt truncation length
+MAX_LLM_RETRIES = 6  # Maximum retry attempts for failed LLM calls
 
 TOPICS = [
     # Incremental Housing
@@ -60,7 +57,7 @@ class RelevanceScore(BaseModel):
 
 
 # Sometimes Ollama calls hang indefinitely. We create a global client with a set timeout to avoid this breaking things.
-ollama_client = Client(timeout=240.0)
+ollama_client = Client(timeout=360.0)
 
 
 def extract_json(text: str) -> str:
@@ -98,8 +95,8 @@ def call_llm(
     """
     Call Ollama LLM with structured output validation and exponential backoff retry logic.
 
-    Uses the global ollama_client with 240s timeout. Retries with exponential backoff (1s, 2s, 4s)
-    on failure. On the third attempt, truncates prompt to RETRY_TRUNCATE_THRESHOLD chars.
+    Uses the global ollama_client with 240s timeout. Retries with exponential backoff (1s, 2s, 4s, etc)
+    on failure.
     Validates that responses are non-empty before returning.
 
     Handles model-specific limitations for structured output (e.g., gpt-oss) by
@@ -132,19 +129,6 @@ def call_llm(
 
     for attempt in range(max_retries):
         try:
-            # Truncate prompt on later attempts to avoid token limit issues
-            if attempt == 2:  # Third attempt
-                if len(original_prompt) > RETRY_TRUNCATE_THRESHOLD:
-                    prompt_base = original_prompt[:RETRY_TRUNCATE_THRESHOLD]
-                    if schema and not use_native_format:
-                        prompt = f"{prompt_base}\n\nRespond with valid JSON matching this schema:\n{json.dumps(schema, indent=2)}"
-                    else:
-                        prompt = prompt_base
-
-                    print(
-                        f"  ⚠ Truncating prompt: {len(original_prompt)} → {len(prompt)} chars"
-                    )
-
             response = ollama_client.chat(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],

--- a/backend/processing/llm_processor.py
+++ b/backend/processing/llm_processor.py
@@ -116,8 +116,6 @@ def call_llm(
     Raises:
         Exception: If all retry attempts fail or LLM returns empty response
     """
-    original_prompt = prompt
-
     # gpt-oss models can fail with "failed to load model vocabulary required for format"
     # when using Ollama's native 'format' parameter. We handle this by moving the
     # schema into the prompt and manually extracting the JSON from the raw response.

--- a/backend/processing/weekly_report_generator.py
+++ b/backend/processing/weekly_report_generator.py
@@ -19,6 +19,7 @@ from models.weekly_report import (
 )
 from models.types import NewsletterID
 from processing.llm_processor import TOPICS, call_llm
+from prompts.weekly_synthesis import FACTUAL_SUMMARY
 from shared.db import get_supabase_client
 
 
@@ -192,35 +193,9 @@ def synthesize_weekly_summary(
     }
     topic_display = topic_names.get(topic, topic.replace("_", " ").title())
 
-    prompt = f"""Synthesize these verified developments about {topic_display} into a 2-4 paragraph weekly summary.
-
-You are writing for Strong Towns Chicago, an advocacy organization that promotes:
-- SAFE STREETS: Protected bike lanes, traffic calming, pedestrian safety, Vision Zero
-- MORE HOUSING: 4-flats, missing middle housing, ADUs, zoning reform, affordable housing
-- PUBLIC TRANSIT: CTA/Metra funding, service improvements, transit-oriented development
-- FISCAL RESPONSIBILITY: Evidence-based policy, transparent budgets, cost-effective infrastructure
-- COMMUNITY ENGAGEMENT: Public meetings, meaningful input, accessible government
-
-**Guidelines:**
-1. Build ONLY from the verified developments below (do not add external information)
-2. Identify patterns, trends, or themes across developments
-3. Apply Strong Towns perspective:
-   - Frame through safety and livability lens
-   - Emphasize evidence and data (safety studies, usage stats, proven outcomes)
-   - Highlight positive progress and growing political will
-   - Acknowledge tensions while grounding analysis in data
-   - Use educational tone (help readers understand why policies matter)
-4. Organize thematically (not chronologically)
-5. Target 2-4 paragraphs (~300-600 words)
-6. Use encouraging, solutions-oriented tone
-7. DO NOT speculate about future outcomes
-8. DO NOT introduce facts not in the list below
-
-**Verified Developments from Week {week_id}:**
-{facts_list}
-
-Write a narrative summary that synthesizes these developments with Strong Towns values.
-"""
+    prompt = FACTUAL_SUMMARY.format(
+        topic_display=topic_display, week_id=week_id, facts_list=facts_list
+    )
 
     try:
         print(f"  → Synthesizing summary for {topic}...")

--- a/backend/processing/weekly_report_generator.py
+++ b/backend/processing/weekly_report_generator.py
@@ -1,0 +1,360 @@
+"""
+Weekly topic report generation for Strong Towns Chicago.
+
+Two-phase LLM processing:
+1. Extract structured facts from newsletters about a topic
+2. Synthesize facts into narrative weekly summary with Strong Towns perspective
+
+Designed to aggregate newsletter content by topic and generate insight-driven summaries.
+"""
+
+from typing import Any
+from datetime import datetime
+
+from models.weekly_report import (
+    FactExtraction,
+    KeyDevelopment,
+    WeeklySynthesis,
+    WeeklyTopicReport,
+)
+from models.types import NewsletterID
+from processing.llm_processor import TOPICS, call_llm
+from shared.db import get_supabase_client
+
+
+def extract_facts_from_single_newsletter(
+    topic: str, newsletter: dict[str, Any], model: str = "gpt-oss:20b"
+) -> list[KeyDevelopment]:
+    """
+    Phase 1a: Extract structured facts from a single newsletter about a topic.
+
+    Analyzes one newsletter and extracts:
+    - Key decisions or announcements
+    - Development approvals or zoning changes
+    - Policy changes or ordinances
+    - Community meetings or hearings
+
+    Args:
+        topic: Topic identifier (from TOPICS constant)
+        newsletter: Newsletter dict with id, subject, plain_text, source_name, ward_number
+        model: Ollama model name
+
+    Returns:
+        List of KeyDevelopment objects with structured facts from this newsletter
+    """
+    ward_info = (
+        f"Ward {newsletter.get('ward_number', 'Unknown')}"
+        if newsletter.get("ward_number")
+        else "Citywide"
+    )
+    source_info = newsletter.get("source_name", "Unknown Source")
+    newsletter_id = newsletter.get("id", "")
+
+    # Build content for single newsletter
+    content = f"""Source: {source_info} ({ward_info})
+Subject: {newsletter["subject"]}
+
+{newsletter["plain_text"]}
+"""
+
+    prompt = f"""Extract key developments from this Chicago alderman newsletter about {topic}.
+
+You are analyzing newsletters for Strong Towns Chicago, an advocacy organization focused on:
+- Safe streets (protected bike lanes, traffic calming, pedestrian safety)
+- More housing (4-flats, missing middle, ADUs, zoning reform)
+- Public transit (CTA/Metra funding, service improvements, transit-oriented development)
+- Fiscal responsibility (transparent budgets, evidence-based policy)
+
+For each development, provide:
+- Concrete, specific description (what happened, where, when)
+- Ward number involved (if mentioned)
+
+ONLY extract developments that are:
+✓ Specific and factual (include locations, dates, numbers)
+✓ Action-oriented (decisions, approvals, announcements, meetings)
+✓ Relevant to Strong Towns priorities above
+
+DO NOT extract:
+✗ Vague mentions without specifics
+✗ Routine announcements (office hours, holiday schedules)
+✗ Speculation or predictions
+
+If no meaningful developments, return empty list.
+
+Available topics: {", ".join(TOPICS)}
+
+Newsletter:
+{content}
+"""
+
+    try:
+        response = call_llm(model, prompt, FactExtraction.model_json_schema())
+        data = FactExtraction.model_validate_json(response)
+
+        # Add newsletter_id to each development
+        for dev in data.developments:
+            dev.newsletter_ids = [NewsletterID(newsletter_id)]
+
+        return data.developments
+
+    except Exception as e:
+        print(f"    ⚠ Extraction failed for newsletter {newsletter_id[:8]}: {e}")
+        return []
+
+
+def extract_facts_from_newsletters(
+    topic: str, newsletters: list[dict[str, Any]], model: str = "gpt-oss:20b"
+) -> list[KeyDevelopment]:
+    """
+    Phase 1b: Extract and aggregate facts from multiple newsletters.
+
+    Processes each newsletter individually to avoid context limit issues,
+    then aggregates all extracted facts.
+
+    Args:
+        topic: Topic identifier (from TOPICS constant)
+        newsletters: List of newsletter dicts with id, subject, plain_text, source, ward
+        model: Ollama model name
+
+    Returns:
+        Aggregated list of KeyDevelopment objects from all newsletters
+    """
+    if not newsletters:
+        print(f"  ℹ No newsletters for {topic}, skipping fact extraction")
+        return []
+
+    print(f"  → Extracting facts for {topic} from {len(newsletters)} newsletters...")
+
+    all_developments = []
+
+    # Process each newsletter individually
+    for i, newsletter in enumerate(newsletters, 1):
+        print(f"    Processing newsletter {i}/{len(newsletters)}...", end=" ")
+        developments = extract_facts_from_single_newsletter(topic, newsletter, model)
+        all_developments.extend(developments)
+        print(f"✓ {len(developments)} developments")
+
+    print(f"  ✓ Extracted {len(all_developments)} total developments")
+    return all_developments
+
+
+def synthesize_weekly_summary(
+    topic: str,
+    facts: list[KeyDevelopment],
+    week_id: str,
+    model: str = "gpt-oss:20b",
+) -> str:
+    """
+    Phase 2: Synthesize facts into narrative weekly summary.
+
+    Takes structured facts and creates a 2-4 paragraph summary that:
+    - Identifies trends or patterns across wards
+    - Highlights most significant developments
+    - Notes any citywide implications
+    - Provides context on topic-specific activity level
+    - Applies Strong Towns perspective (safe streets, more housing, transit, fiscal responsibility)
+
+    Args:
+        topic: Topic identifier (from TOPICS constant)
+        facts: Extracted KeyDevelopment objects from Phase 1
+        week_id: Week identifier (YYYY-WXX)
+        model: Ollama model name
+
+    Returns:
+        Weekly summary text (2-4 paragraphs)
+    """
+    if not facts:
+        print(f"  ℹ No facts to synthesize for {topic}")
+        return ""
+
+    # Format facts for prompt
+    facts_text = []
+    for i, fact in enumerate(facts, 1):
+        ward_str = f"Wards {', '.join(fact.wards)}" if fact.wards else "Citywide"
+        facts_text.append(f"{i}. {fact.description} ({ward_str})")
+
+    facts_list = "\n".join(facts_text)
+
+    # Map topic to friendly name for summary
+    topic_names = {
+        "4_flats_legalization": "4-Flats and Small-Scale Housing",
+        "missing_middle_housing": "Missing Middle Housing",
+        "accessory_dwelling_units": "Accessory Dwelling Units (ADUs)",
+        "single_stair_reform": "Single-Stair Building Reform",
+        "bike_lanes": "Bike Lanes and Cycling Infrastructure",
+        "street_redesign": "Street Redesign and Reconstruction",
+        "street_safety_or_traffic_calming": "Street Safety and Traffic Calming",
+        "transit_funding": "Public Transit Funding and Service",
+        "city_budget": "City Budget and Fiscal Policy",
+        "tax_policy": "Tax Policy and Revenue",
+        "zoning_or_development_meeting_or_approval": "Zoning and Development Approvals",
+        "city_charter": "City Charter and Governance Reform",
+    }
+    topic_display = topic_names.get(topic, topic.replace("_", " ").title())
+
+    prompt = f"""Synthesize these verified developments about {topic_display} into a 2-4 paragraph weekly summary.
+
+You are writing for Strong Towns Chicago, an advocacy organization that promotes:
+- SAFE STREETS: Protected bike lanes, traffic calming, pedestrian safety, Vision Zero
+- MORE HOUSING: 4-flats, missing middle housing, ADUs, zoning reform, affordable housing
+- PUBLIC TRANSIT: CTA/Metra funding, service improvements, transit-oriented development
+- FISCAL RESPONSIBILITY: Evidence-based policy, transparent budgets, cost-effective infrastructure
+- COMMUNITY ENGAGEMENT: Public meetings, meaningful input, accessible government
+
+**Guidelines:**
+1. Build ONLY from the verified developments below (do not add external information)
+2. Identify patterns, trends, or themes across developments
+3. Apply Strong Towns perspective:
+   - Frame through safety and livability lens
+   - Emphasize evidence and data (safety studies, usage stats, proven outcomes)
+   - Highlight positive progress and growing political will
+   - Acknowledge tensions while grounding analysis in data
+   - Use educational tone (help readers understand why policies matter)
+4. Organize thematically (not chronologically)
+5. Target 2-4 paragraphs (~300-600 words)
+6. Use encouraging, solutions-oriented tone
+7. DO NOT speculate about future outcomes
+8. DO NOT introduce facts not in the list below
+
+**Verified Developments from Week {week_id}:**
+{facts_list}
+
+Write a narrative summary that synthesizes these developments with Strong Towns values.
+"""
+
+    try:
+        print(f"  → Synthesizing summary for {topic}...")
+        response = call_llm(model, prompt, WeeklySynthesis.model_json_schema())
+        data = WeeklySynthesis.model_validate_json(response)
+
+        print(f"  ✓ Generated summary ({len(data.summary)} chars)")
+        return data.summary
+
+    except Exception as e:
+        print(f"  ✗ Summary synthesis failed for {topic}: {e}")
+        return ""
+
+
+def generate_weekly_topic_report(
+    topic: str, week_id: str, model: str = "gpt-oss:20b"
+) -> WeeklyTopicReport | None:
+    """
+    Complete pipeline: Fetch newsletters, extract facts, synthesize summary.
+
+    Orchestrates the full two-phase process:
+    1. Query newsletters tagged with topic from specified week
+    2. Extract structured facts via LLM (Phase 1)
+    3. Synthesize narrative summary via LLM (Phase 2)
+    4. Return complete WeeklyTopicReport object
+
+    Returns None if no newsletters found for topic/week or if processing fails.
+
+    Args:
+        topic: Topic identifier (from TOPICS constant)
+        week_id: Week identifier (YYYY-WXX)
+        model: Ollama model name
+
+    Returns:
+        WeeklyTopicReport object or None if no content or processing failed
+    """
+    # Validate topic
+    if topic not in TOPICS:
+        print(f"  ✗ Invalid topic: {topic}")
+        return None
+
+    # Parse week_id to get date range
+    try:
+        year_str, week_str = week_id.split("-W")
+        year = int(year_str)
+        week = int(week_str)
+    except ValueError:
+        print(f"  ✗ Invalid week_id format: {week_id} (expected YYYY-WXX)")
+        return None
+
+    # Query newsletters for this topic and week
+    print(f"\n=== Generating report for {topic} (week {week_id}) ===")
+
+    supabase = get_supabase_client()
+
+    try:
+        # Use PostgreSQL's ISO week functions to filter by week
+        response = (
+            supabase.table("newsletters")
+            .select(
+                "id, subject, plain_text, received_date, source:sources(name, ward_number)"
+            )
+            .filter("topics", "cs", f"{{{topic}}}")  # Contains topic
+            .execute()
+        )
+
+        # Filter results to only include newsletters from the target week
+        # (Supabase PostgREST doesn't support EXTRACT directly, so we filter in Python)
+        newsletters = []
+        for nl_data in response.data:
+            # Type assertions for Supabase response
+            nl_dict = dict(nl_data)  # type: ignore
+            received_date = datetime.fromisoformat(
+                str(nl_dict["received_date"]).replace("Z", "+00:00")
+            )
+            nl_year, nl_week, _ = received_date.isocalendar()
+            if nl_year == year and nl_week == week:
+                # Flatten source data
+                source_data = nl_dict.get("source")
+                newsletter = {
+                    "id": str(nl_dict["id"]),
+                    "subject": str(nl_dict["subject"]),
+                    "plain_text": str(nl_dict["plain_text"] or ""),
+                    "received_date": str(nl_dict["received_date"]),
+                    "source_name": str(source_data["name"])
+                    if source_data and isinstance(source_data, dict)
+                    else "Unknown",
+                    "ward_number": str(source_data["ward_number"])
+                    if source_data
+                    and isinstance(source_data, dict)
+                    and source_data.get("ward_number")
+                    else None,
+                }
+                newsletters.append(newsletter)
+
+        if not newsletters:
+            print(f"  ℹ No newsletters found for {topic} in week {week_id}")
+            return None
+
+        print(f"  ✓ Found {len(newsletters)} newsletters")
+
+        # Phase 1: Extract facts (per-newsletter, then aggregate)
+        facts = extract_facts_from_newsletters(topic, newsletters, model)
+
+        if not facts:
+            print("  ℹ No developments extracted, skipping report generation")
+            return None
+
+        # Phase 2: Synthesize summary
+        summary = synthesize_weekly_summary(topic, facts, week_id, model)
+
+        if not summary:
+            print("  ℹ No summary generated, skipping report creation")
+            return None
+
+        # Build report object
+        newsletter_ids: list[NewsletterID] = []
+        for nl in newsletters:
+            nl_id = nl.get("id")
+            if nl_id:
+                newsletter_ids.append(NewsletterID(nl_id))
+        report = WeeklyTopicReport(
+            id="",  # Will be generated by database
+            topic=topic,
+            week_id=week_id,
+            report_summary=summary,
+            newsletter_ids=newsletter_ids,
+            key_developments=facts,
+            created_at=datetime.now(),
+        )
+
+        print("  ✓ Report generated successfully")
+        return report
+
+    except Exception as e:
+        print(f"  ✗ Report generation failed: {e}")
+        return None

--- a/backend/prompts/__init__.py
+++ b/backend/prompts/__init__.py
@@ -1,0 +1,5 @@
+"""Prompt templates for LLM processing."""
+
+from prompts.weekly_synthesis import FACTUAL_SUMMARY
+
+__all__ = ["FACTUAL_SUMMARY"]

--- a/backend/prompts/weekly_synthesis.py
+++ b/backend/prompts/weekly_synthesis.py
@@ -1,0 +1,37 @@
+"""
+Prompt templates for weekly report synthesis.
+
+Templates use .format() for variable substitution.
+Available variables: {topic_display}, {week_id}, {facts_list}
+"""
+
+FACTUAL_SUMMARY = """Synthesize these developments about {topic_display} into a concise weekly summary.
+
+You are writing for Strong Towns Chicago, an advocacy organization that promotes:
+- MORE HOUSING: 4-flats, missing middle housing, ADUs, zoning reform, affordable housing, incremental development
+- PUBLIC TRANSIT: CTA/Metra funding, service improvements, transit-oriented development
+- SAFE STREETS: Protected bike lanes, traffic calming, pedestrian safety
+- FISCAL RESPONSIBILITY: transparent budgets, cost-effective infrastructure
+
+Your audience is Chicago residents tracking local government activity. They want the relevant FACTS clearly extracted from the newsletters.
+
+**Guidelines:**
+1. Report what happened, where, and which ward(s) it came from
+2. Be specific: Include locations, ward numbers, dates, and concrete details
+3. Group by theme only if it adds clarity
+4. Use simple, direct language - no fluff, no marketing speak
+5. Write 2-3 paragraphs (~200-400 words)
+6. DO NOT add context or data not in the developments below
+7. DO NOT editorialize or interpret significance
+8. DO NOT use phrases like "data-driven," "evidence shows," or "evidence-based"
+
+**Format:**
+- Lead with the most significant or widespread development
+- Clearly state which ward each item is from
+- Use ward names consistently (e.g. "the 40th Ward")
+
+**Verified Developments from Week {week_id}:**
+{facts_list}
+
+Write a factual summary reporting what aldermen announced this week.
+"""

--- a/backend/tests/integration/test_empty_digest_flow.py
+++ b/backend/tests/integration/test_empty_digest_flow.py
@@ -1,0 +1,108 @@
+"""
+Integration test for the empty digest prevention flow.
+
+Verifies that when a notification queue entry points to a missing newsletter,
+the system correctly skips sending the email and marks the notification as failed.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+from notifications.process_notification_queue import process_daily_digests
+
+
+class TestEmptyDigestFlow(unittest.TestCase):
+    """Integration tests for end-to-end empty digest handling."""
+
+    @patch("builtins.print")
+    @patch("notifications.process_notification_queue.get_supabase_client")
+    @patch("notifications.rule_matcher.get_supabase_client")
+    @patch("notifications.email_sender.resend.Emails.send")
+    @patch("notifications.email_sender._build_unsubscribe_url")
+    def test_empty_daily_digest_flow(
+        self, mock_unsub, mock_resend, mock_sb_matcher, mock_sb_process, mock_print
+    ):
+        """
+        Test flow where a notification in the queue references a missing newsletter.
+        Expected: No email sent, status updated to failed with 'Empty digest content'.
+        """
+        # Arrange
+        mock_sb = MagicMock()
+        mock_sb_matcher.return_value = mock_sb
+        mock_sb_process.return_value = mock_sb
+        mock_unsub.return_value = "https://example.com/unsub"
+
+        batch_id = "2026-01-31"
+        user_id = "user_123"
+        newsletter_id = "nl_999"  # Non-existent newsletter
+
+        # 1. Mock fetch of pending notifications
+        mock_queue_response = MagicMock()
+        mock_queue_response.data = [
+            {
+                "id": "notif_1",
+                "user_id": user_id,
+                "newsletter_id": newsletter_id,
+                "rule_id": "rule_1",
+                "newsletter": None,  # Key part: newsletter is missing from join
+                "rule": {"name": "Test Rule"},
+            }
+        ]
+
+        # Route table calls
+        mock_queue_table = MagicMock()
+
+        # Simplify the chain mock using configure_mock or just return values
+        mock_queue_table.select.return_value.eq.return_value.order.return_value.eq.return_value.execute.return_value = mock_queue_response
+
+        # 2. Mock user profile fetch
+        mock_user_response = MagicMock()
+        mock_user_response.data = {
+            "email": "test@example.com",
+            "notification_preferences": {"enabled": True},
+        }
+
+        mock_user_table = MagicMock()
+        mock_user_table.select.return_value.eq.return_value.single.return_value.execute.return_value = mock_user_response
+
+        # 3. Mock updates and inserts
+        mock_history_table = MagicMock()
+
+        def table_router(name):
+            if name == "notification_queue":
+                return mock_queue_table
+            if name == "user_profiles":
+                return mock_user_table
+            if name == "notification_history":
+                return mock_history_table
+            return MagicMock()
+
+        mock_sb.table.side_effect = table_router
+
+        # Act
+        with patch(
+            "notifications.process_notification_queue.ZoneInfo"
+        ):  # Avoid TZ issues
+            stats = process_daily_digests(batch_id=batch_id)
+
+        # Assert
+        # Verify stats
+        self.assertEqual(stats["skipped"], 1)
+        self.assertEqual(stats["sent"], 0)
+
+        # Verify Resend was NOT called
+        mock_resend.assert_not_called()
+
+        # Verify DB update to notification_queue
+        mock_queue_table.update.assert_called_with(
+            {"status": "failed", "error_message": "Empty digest content"}
+        )
+
+        # Verify history record
+        mock_history_table.insert.assert_called_once()
+        history_call_data = mock_history_table.insert.call_args[0][0]
+        self.assertEqual(history_call_data["success"], False)
+        self.assertEqual(history_call_data["error_message"], "Empty digest content")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/integration/test_notification_matching.py
+++ b/backend/tests/integration/test_notification_matching.py
@@ -51,10 +51,18 @@ class TestNotificationMatching(unittest.TestCase):
                 "min_relevance_score": None,
                 "source_ids": None,
                 "ward_numbers": None,
+                "delivery_frequency": "daily",
             }
         ]
-        mock_rules_eq.execute.return_value = mock_rules_response
-        mock_rules_select.eq.return_value = mock_rules_eq
+        
+        # Handle chained .eq() calls: .eq(active).eq(daily)
+        mock_rules_eq_daily = MagicMock()
+        mock_rules_eq_daily.execute.return_value = mock_rules_response
+        
+        mock_rules_eq_active = MagicMock()
+        mock_rules_eq_active.eq.return_value = mock_rules_eq_daily
+        
+        mock_rules_select.eq.return_value = mock_rules_eq_active
         mock_rules_table.select.return_value = mock_rules_select
 
         # Mock user preferences query
@@ -142,6 +150,7 @@ class TestNotificationMatching(unittest.TestCase):
                 "min_relevance_score": None,
                 "source_ids": None,
                 "ward_numbers": ["10"],
+                "delivery_frequency": "daily",
             }
         ]
 
@@ -161,7 +170,8 @@ class TestNotificationMatching(unittest.TestCase):
                 return mock_update_table
             if table_name == "notification_rules":
                 mock_rules_table = MagicMock()
-                mock_rules_table.select.return_value.eq.return_value.execute.return_value = mock_rules_response
+                # Handle .select().eq().eq().execute()
+                mock_rules_table.select.return_value.eq.return_value.eq.return_value.execute.return_value = mock_rules_response
                 return mock_rules_table
             elif table_name == "user_profiles":
                 mock_users_table = MagicMock()

--- a/backend/tests/integration/test_notification_matching.py
+++ b/backend/tests/integration/test_notification_matching.py
@@ -39,7 +39,6 @@ class TestNotificationMatching(unittest.TestCase):
         # Mock active rules query
         mock_rules_table = MagicMock()
         mock_rules_select = MagicMock()
-        mock_rules_eq = MagicMock()
         mock_rules_response = MagicMock()
         mock_rules_response.data = [
             {
@@ -54,14 +53,14 @@ class TestNotificationMatching(unittest.TestCase):
                 "delivery_frequency": "daily",
             }
         ]
-        
+
         # Handle chained .eq() calls: .eq(active).eq(daily)
         mock_rules_eq_daily = MagicMock()
         mock_rules_eq_daily.execute.return_value = mock_rules_response
-        
+
         mock_rules_eq_active = MagicMock()
         mock_rules_eq_active.eq.return_value = mock_rules_eq_daily
-        
+
         mock_rules_select.eq.return_value = mock_rules_eq_active
         mock_rules_table.select.return_value = mock_rules_select
 

--- a/backend/tests/integration/test_notification_matching.py
+++ b/backend/tests/integration/test_notification_matching.py
@@ -178,7 +178,9 @@ class TestNotificationMatching(unittest.TestCase):
         mock_supabase.table.side_effect = table_router
 
         # Mock LLM processor
-        with patch("utils.process_llm_metadata.process_with_ollama") as mock_llm:
+        with patch(
+            "utils.process_llm_metadata.extract_newsletter_metadata"
+        ) as mock_llm:
             mock_llm.return_value = {
                 "topics": ["bike_lanes"],
                 "summary": "Newsletter about bike lanes",

--- a/backend/tests/unit/test_digest_system.py
+++ b/backend/tests/unit/test_digest_system.py
@@ -1,0 +1,265 @@
+"""
+Unit tests for generic digest system (email_sender.py + process_notification_queue.py)
+
+Tests template selection, business rules, error handling.
+"""
+
+import unittest
+from unittest.mock import patch
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from notifications.email_sender import (
+    DigestType,
+    send_digest,
+    _build_digest_html,
+    _build_digest_text,
+)
+from notifications.process_notification_queue import (
+    _calculate_daily_batch_id,
+    _calculate_weekly_batch_id,
+    process_digests,
+)
+
+
+class TestDigestEmailTemplates(unittest.TestCase):
+    """Tests for template-based digest generation."""
+
+    def test_daily_uses_newsletter_template(self):
+        """Daily digest uses newsletter card template."""
+        prepared = [
+            {
+                "title": "Test",
+                "source_name": "Test",
+                "ward_text": "",
+                "date_formatted": "Jan 1",
+                "summary": "",
+                "topics": [],
+                "newsletter_url": "http://test.com",
+                "matched_rules": [],
+            }
+        ]
+
+        html = _build_digest_html(
+            prepared, DigestType.DAILY, "http://prefs.com", "http://unsub.com"
+        )
+
+        self.assertIn("Daily Chicago Aldermen Newsletter Digest", html)
+        self.assertIn('class="newsletter"', html)
+
+    def test_weekly_uses_topic_report_template(self):
+        """Weekly digest uses topic report template."""
+        prepared = [
+            {
+                "topic": "bike_lanes",
+                "topic_display": "Bike Lanes",
+                "summary": "Summary",
+                "newsletter_count": 5,
+                "week_range": "Jan 1-7",
+                "week_id": "2026-W01",
+                "matched_rules": [],
+            }
+        ]
+
+        html = _build_digest_html(
+            prepared, DigestType.WEEKLY, "http://prefs.com", "http://unsub.com"
+        )
+
+        self.assertIn("Weekly Topic Digest", html)
+        self.assertIn('class="topic-report"', html)
+
+    def test_daily_text_format_differs_from_weekly(self):
+        """Daily and weekly text formats are distinct."""
+        daily_data = [
+            {
+                "title": "Test",
+                "source_name": "Test",
+                "ward_text": "",
+                "date_formatted": "Jan 1",
+                "summary": "",
+                "topics": [],
+                "newsletter_url": "http://test.com",
+                "matched_rules": [],
+            }
+        ]
+
+        weekly_data = [
+            {
+                "topic": "bike_lanes",
+                "topic_display": "Bike Lanes",
+                "summary": "Summary",
+                "newsletter_count": 5,
+                "week_range": "Jan 1-7",
+                "week_id": "2026-W01",
+                "matched_rules": [],
+            }
+        ]
+
+        daily_text = _build_digest_text(
+            daily_data, DigestType.DAILY, "http://p.com", "http://u.com"
+        )
+        weekly_text = _build_digest_text(
+            weekly_data, DigestType.WEEKLY, "http://p.com", "http://u.com"
+        )
+
+        self.assertIn("DAILY NEWSLETTER DIGEST", daily_text)
+        self.assertIn("WEEKLY TOPIC DIGEST", weekly_text)
+
+    def test_topic_limit_business_rule(self):
+        """Only first 5 topics shown (business rule enforcement)."""
+        from notifications.email_sender import _render_daily_content_html
+
+        prepared = [
+            {
+                "title": "Test",
+                "source_name": "Test",
+                "ward_text": "",
+                "date_formatted": "Jan 1",
+                "summary": "",
+                "topics": ["t1", "t2", "t3", "t4", "t5", "t6", "t7"],
+                "newsletter_url": "http://test.com",
+                "matched_rules": [],
+            }
+        ]
+
+        html = _render_daily_content_html(prepared)
+
+        # Business rule: max 5 topics displayed
+        self.assertIn("t5", html)
+        self.assertNotIn("t6", html)
+
+
+class TestDigestSending(unittest.TestCase):
+    """Tests for unified send_digest() function."""
+
+    @patch("notifications.email_sender.resend.Emails.send")
+    @patch("notifications.email_sender._prepare_newsletter_data")
+    @patch("notifications.email_sender.generate_unsubscribe_token")
+    def test_sends_correct_digest_type(self, mock_token, mock_prepare, mock_resend):
+        """Correct digest type reflected in subject and routing."""
+        mock_token.return_value = "test-token"
+        mock_prepare.return_value = [
+            {
+                "title": "Test",
+                "source_name": "Test",
+                "ward_text": "",
+                "date_formatted": "Jan 1",
+                "summary": "",
+                "topics": [],
+                "newsletter_url": "http://test.com",
+                "matched_rules": [],
+            }
+        ]
+        mock_resend.return_value = {"id": "email-123"}
+
+        # Act - Send DAILY
+        result = send_digest(
+            "user-1",
+            "test@example.com",
+            [{"newsletter": {}, "rule": {}}],
+            DigestType.DAILY,
+        )
+
+        # Assert
+        self.assertTrue(result["success"])
+        call_args = mock_resend.call_args[0][0]
+        self.assertIn("Daily", call_args["subject"])
+
+    @patch("notifications.email_sender.resend.Emails.send")
+    @patch("notifications.email_sender._prepare_newsletter_data")
+    @patch("notifications.email_sender.generate_unsubscribe_token")
+    def test_handles_sending_errors_gracefully(
+        self, mock_token, mock_prepare, mock_resend
+    ):
+        """Email sending errors don't crash, return error dict."""
+        mock_token.return_value = "test-token"
+        mock_prepare.return_value = [
+            {
+                "title": "Test",
+                "source_name": "Test",
+                "ward_text": "",
+                "date_formatted": "Jan 1",
+                "summary": "",
+                "topics": [],
+                "newsletter_url": "http://test.com",
+                "matched_rules": [],
+            }
+        ]
+        mock_resend.side_effect = Exception("Resend API error")
+
+        # Act
+        result = send_digest(
+            "user-1",
+            "test@example.com",
+            [{"newsletter": {}, "rule": {}}],
+            DigestType.DAILY,
+        )
+
+        # Assert
+        self.assertFalse(result["success"])
+        self.assertIn("Resend API error", result["error"])
+
+
+class TestBatchIdCalculation(unittest.TestCase):
+    """Tests for batch ID calculation functions."""
+
+    @patch("notifications.process_notification_queue.datetime")
+    def test_calculates_yesterday_chicago_time(self, mock_datetime):
+        """Daily batch ID is yesterday in Chicago timezone."""
+        chicago_tz = ZoneInfo("America/Chicago")
+        mock_now = datetime(2026, 1, 26, 10, 0, 0, tzinfo=chicago_tz)
+        mock_datetime.now.return_value = mock_now
+
+        result = _calculate_daily_batch_id()
+
+        self.assertEqual(result, "2026-01-25")
+
+    @patch("notifications.process_notification_queue.datetime")
+    def test_calculates_previous_iso_week(self, mock_datetime):
+        """Weekly batch ID is previous week in ISO format."""
+        chicago_tz = ZoneInfo("America/Chicago")
+        mock_now = datetime(2026, 1, 26, 10, 0, 0, tzinfo=chicago_tz)  # Monday of W05
+        mock_datetime.now.return_value = mock_now
+
+        result = _calculate_weekly_batch_id()
+
+        self.assertEqual(result, "2026-W04")  # Previous week
+
+
+class TestDigestProcessing(unittest.TestCase):
+    """Tests for process_digests() workflow."""
+
+    def setUp(self):
+        """Suppress print output."""
+        import sys
+        import io
+
+        self.held_output = io.StringIO()
+        sys.stdout = self.held_output
+
+    def tearDown(self):
+        """Restore stdout."""
+        import sys
+
+        sys.stdout = sys.__stdout__
+
+    @patch("notifications.process_notification_queue.get_pending_notifications_by_user")
+    def test_dry_run_counts_but_doesnt_send(self, mock_get_notifs):
+        """Dry run mode processes notifications without sending emails."""
+        mock_get_notifs.return_value = {
+            "user-1": [{"id": "notif-1", "newsletter_id": "nl-1", "rule_id": "rule-1"}]
+        }
+
+        with patch("notifications.process_notification_queue.get_supabase_client"):
+            with patch(
+                "notifications.process_notification_queue.send_digest"
+            ) as mock_send:
+                result = process_digests(DigestType.DAILY, "2026-01-25", dry_run=True)
+
+        # Assert - counted but not sent
+        self.assertEqual(result["sent"], 1)
+        mock_send.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_email_sender.py
+++ b/backend/tests/unit/test_email_sender.py
@@ -13,6 +13,7 @@ from notifications.email_sender import (
     send_daily_digest,
     _build_digest_html,
     _build_digest_text,
+    DigestType,
 )
 from tests.fixtures.newsletter_factory import create_test_newsletter, create_test_source
 
@@ -311,7 +312,10 @@ class TestBuildDigestHtml(unittest.TestCase):
         ]
 
         html = _build_digest_html(
-            prepared, "http://example.com/prefs", "http://example.com/unsub"
+            prepared,
+            DigestType.DAILY,
+            "http://example.com/prefs",
+            "http://example.com/unsub",
         )
 
         self.assertIn("Newsletter 1", html)
@@ -333,7 +337,10 @@ class TestBuildDigestHtml(unittest.TestCase):
         ]
 
         html = _build_digest_html(
-            prepared, "http://example.com/prefs", "http://example.com/unsub"
+            prepared,
+            DigestType.DAILY,
+            "http://example.com/prefs",
+            "http://example.com/unsub",
         )
 
         self.assertIn("Zoning Updates", html)
@@ -355,7 +362,10 @@ class TestBuildDigestHtml(unittest.TestCase):
         ]
 
         html = _build_digest_html(
-            prepared, "http://example.com/prefs", "http://example.com/unsub"
+            prepared,
+            DigestType.DAILY,
+            "http://example.com/prefs",
+            "http://example.com/unsub",
         )
 
         self.assertIn("zoning", html)
@@ -378,7 +388,10 @@ class TestBuildDigestHtml(unittest.TestCase):
         ]
 
         html = _build_digest_html(
-            prepared, "http://example.com/prefs", "http://example.com/unsub"
+            prepared,
+            DigestType.DAILY,
+            "http://example.com/prefs",
+            "http://example.com/unsub",
         )
 
         self.assertIn("topic5", html)
@@ -400,7 +413,10 @@ class TestBuildDigestHtml(unittest.TestCase):
         ]
 
         html = _build_digest_html(
-            prepared, "http://example.com/preferences", "http://example.com/unsub"
+            prepared,
+            DigestType.DAILY,
+            "http://example.com/preferences",
+            "http://example.com/unsub",
         )
 
         self.assertIn("http://example.com/preferences", html)
@@ -425,7 +441,10 @@ class TestBuildDigestText(unittest.TestCase):
         ]
 
         text = _build_digest_text(
-            prepared, "http://example.com/prefs", "http://example.com/unsub"
+            prepared,
+            DigestType.DAILY,
+            "http://example.com/prefs",
+            "http://example.com/unsub",
         )
 
         self.assertIn("DAILY NEWSLETTER DIGEST", text)
@@ -458,7 +477,10 @@ class TestBuildDigestText(unittest.TestCase):
         ]
 
         text = _build_digest_text(
-            prepared, "http://example.com/prefs", "http://example.com/unsub"
+            prepared,
+            DigestType.DAILY,
+            "http://example.com/prefs",
+            "http://example.com/unsub",
         )
 
         self.assertIn("1. Newsletter 1", text)
@@ -480,7 +502,10 @@ class TestBuildDigestText(unittest.TestCase):
         ]
 
         text = _build_digest_text(
-            prepared, "http://example.com/prefs", "http://example.com/unsub"
+            prepared,
+            DigestType.DAILY,
+            "http://example.com/prefs",
+            "http://example.com/unsub",
         )
 
         self.assertIn("Zoning Updates", text)
@@ -501,7 +526,10 @@ class TestBuildDigestText(unittest.TestCase):
         ]
 
         text = _build_digest_text(
-            prepared, "http://example.com/prefs", "http://example.com/unsub"
+            prepared,
+            DigestType.DAILY,
+            "http://example.com/prefs",
+            "http://example.com/unsub",
         )
 
         self.assertIn("zoning", text)
@@ -523,7 +551,10 @@ class TestBuildDigestText(unittest.TestCase):
         ]
 
         text = _build_digest_text(
-            prepared, "http://example.com/prefs", "http://example.com/unsub"
+            prepared,
+            DigestType.DAILY,
+            "http://example.com/prefs",
+            "http://example.com/unsub",
         )
 
         self.assertIn("http://example.com/prefs", text)

--- a/backend/tests/unit/test_email_sender_digest_types.py
+++ b/backend/tests/unit/test_email_sender_digest_types.py
@@ -244,7 +244,7 @@ class TestRenderWeeklyContentHtml(unittest.TestCase):
         html = _render_weekly_content_html(prepared)
 
         # Assert
-        self.assertIn("/search?topics=transit_funding", html)
+        self.assertIn("/search?topic=transit_funding", html)
 
 
 class TestBuildDigestHtml(unittest.TestCase):

--- a/backend/tests/unit/test_email_sender_digest_types.py
+++ b/backend/tests/unit/test_email_sender_digest_types.py
@@ -1,0 +1,389 @@
+"""
+Unit tests for generic digest system in notifications/email_sender.py
+
+Tests DigestType enum, unified send_digest function, and template rendering.
+"""
+
+import unittest
+from unittest.mock import patch
+from notifications.email_sender import (
+    DigestType,
+    send_digest,
+    _render_daily_content_html,
+    _render_weekly_content_html,
+    _build_digest_html,
+    _build_digest_text,
+)
+
+
+class TestDigestType(unittest.TestCase):
+    """Tests for DigestType enum."""
+
+    def test_has_daily_and_weekly_types(self):
+        """Enum contains DAILY and WEEKLY."""
+        self.assertEqual(DigestType.DAILY.value, "daily")
+        self.assertEqual(DigestType.WEEKLY.value, "weekly")
+
+
+class TestSendDigest(unittest.TestCase):
+    """Tests for unified send_digest() function."""
+
+    @patch("notifications.email_sender.resend.Emails.send")
+    @patch("notifications.email_sender._prepare_newsletter_data")
+    @patch("notifications.email_sender.generate_unsubscribe_token")
+    def test_sends_daily_digest(self, mock_token, mock_prepare, mock_resend):
+        """Daily digest sent with correct type."""
+        # Arrange
+        mock_token.return_value = "test-token"
+        mock_prepare.return_value = [
+            {
+                "title": "Test",
+                "source_name": "Test",
+                "ward_text": "",
+                "date_formatted": "Jan 1",
+                "summary": "",
+                "topics": [],
+                "newsletter_url": "http://test.com",
+                "matched_rules": [],
+            }
+        ]
+        mock_resend.return_value = {"id": "email-123"}
+
+        notifications = [{"newsletter": {}, "rule": {}}]
+
+        # Act
+        result = send_digest(
+            "user-1",
+            "test@example.com",
+            notifications,
+            DigestType.DAILY,
+            "http://prefs.com",
+        )
+
+        # Assert
+        self.assertTrue(result["success"])
+        self.assertEqual(result["email_id"], "email-123")
+        mock_resend.assert_called_once()
+
+        # Verify subject line
+        call_args = mock_resend.call_args[0][0]
+        self.assertIn("Daily", call_args["subject"])
+
+    @patch("notifications.email_sender.resend.Emails.send")
+    @patch("notifications.email_sender._prepare_weekly_report_data")
+    @patch("notifications.email_sender.generate_unsubscribe_token")
+    def test_sends_weekly_digest(self, mock_token, mock_prepare, mock_resend):
+        """Weekly digest sent with correct type."""
+        # Arrange
+        mock_token.return_value = "test-token"
+        mock_prepare.return_value = [
+            {
+                "topic": "bike_lanes",
+                "topic_display": "Bike Lanes",
+                "summary": "Summary",
+                "newsletter_count": 5,
+                "week_range": "Jan 1-7",
+                "week_id": "2026-W01",
+                "matched_rules": ["Test Rule"],
+            }
+        ]
+        mock_resend.return_value = {"id": "email-456"}
+
+        notifications = [{"weekly_topic_reports": {}, "rule": {}}]
+
+        # Act
+        result = send_digest(
+            "user-2",
+            "test@example.com",
+            notifications,
+            DigestType.WEEKLY,
+            "http://prefs.com",
+        )
+
+        # Assert
+        self.assertTrue(result["success"])
+        self.assertEqual(result["email_id"], "email-456")
+
+        # Verify subject line
+        call_args = mock_resend.call_args[0][0]
+        self.assertIn("Weekly", call_args["subject"])
+        self.assertIn("Topic", call_args["subject"])
+
+    @patch("notifications.email_sender.resend.Emails.send")
+    @patch("notifications.email_sender._prepare_newsletter_data")
+    @patch("notifications.email_sender.generate_unsubscribe_token")
+    def test_handles_sending_failure(self, mock_token, mock_prepare, mock_resend):
+        """Returns error on Resend failure."""
+        # Arrange
+        mock_token.return_value = "test-token"
+        mock_prepare.return_value = [
+            {
+                "title": "Test",
+                "source_name": "Test",
+                "ward_text": "",
+                "date_formatted": "Jan 1",
+                "summary": "",
+                "topics": [],
+                "newsletter_url": "http://test.com",
+                "matched_rules": [],
+            }
+        ]
+        mock_resend.side_effect = Exception("Resend API error")
+
+        notifications = [{"newsletter": {}, "rule": {}}]
+
+        # Act
+        result = send_digest(
+            "user-3", "test@example.com", notifications, DigestType.DAILY
+        )
+
+        # Assert
+        self.assertFalse(result["success"])
+        self.assertIn("error", result)
+        self.assertIn("Resend API error", result["error"])
+
+
+class TestRenderDailyContentHtml(unittest.TestCase):
+    """Tests for _render_daily_content_html() function."""
+
+    def test_renders_newsletter_cards(self):
+        """Newsletter data rendered as HTML cards."""
+        # Arrange
+        prepared = [
+            {
+                "title": "Test Newsletter",
+                "source_name": "Ald. Smith",
+                "ward_text": " (Ward 10)",
+                "date_formatted": "January 25, 2026",
+                "summary": "Test summary",
+                "topics": ["bike_lanes", "transit"],
+                "newsletter_url": "http://example.com/nl/1",
+                "matched_rules": ["Rule 1"],
+            }
+        ]
+
+        # Act
+        html = _render_daily_content_html(prepared)
+
+        # Assert
+        self.assertIn("Test Newsletter", html)
+        self.assertIn("Ald. Smith", html)
+        self.assertIn("Ward 10", html)
+        self.assertIn("Test summary", html)
+        self.assertIn("bike_lanes", html)
+        self.assertIn("Rule 1", html)
+
+    def test_limits_topics_to_five(self):
+        """Only first 5 topics rendered."""
+        # Arrange
+        prepared = [
+            {
+                "title": "Test",
+                "source_name": "Test",
+                "ward_text": "",
+                "date_formatted": "Jan 1",
+                "summary": "",
+                "topics": ["t1", "t2", "t3", "t4", "t5", "t6", "t7"],
+                "newsletter_url": "http://test.com",
+                "matched_rules": [],
+            }
+        ]
+
+        # Act
+        html = _render_daily_content_html(prepared)
+
+        # Assert
+        self.assertIn("t5", html)
+        self.assertNotIn("t6", html)
+
+
+class TestRenderWeeklyContentHtml(unittest.TestCase):
+    """Tests for _render_weekly_content_html() function."""
+
+    def test_renders_topic_reports(self):
+        """Topic report data rendered as HTML."""
+        # Arrange
+        prepared = [
+            {
+                "topic": "bike_lanes",
+                "topic_display": "Bike Lanes and Cycling Infrastructure",
+                "summary": "This week saw progress on bike lanes in multiple wards.",
+                "newsletter_count": 8,
+                "week_range": "January 20-26, 2026",
+                "week_id": "2026-W04",
+                "matched_rules": ["My Bike Rule"],
+            }
+        ]
+
+        # Act
+        html = _render_weekly_content_html(prepared)
+
+        # Assert
+        self.assertIn("Bike Lanes and Cycling Infrastructure", html)
+        self.assertIn("8 newsletters", html)
+        self.assertIn("January 20-26, 2026", html)
+        self.assertIn("progress on bike lanes", html)
+        self.assertIn("My Bike Rule", html)
+
+    def test_includes_search_link(self):
+        """Search link for topic included."""
+        # Arrange
+        prepared = [
+            {
+                "topic": "transit_funding",
+                "topic_display": "Transit",
+                "summary": "Summary",
+                "newsletter_count": 3,
+                "week_range": "Jan 1-7",
+                "week_id": "2026-W01",
+                "matched_rules": [],
+            }
+        ]
+
+        # Act
+        html = _render_weekly_content_html(prepared)
+
+        # Assert
+        self.assertIn("/search?topics=transit_funding", html)
+
+
+class TestBuildDigestHtml(unittest.TestCase):
+    """Tests for unified _build_digest_html() function."""
+
+    def test_uses_daily_template_for_daily_type(self):
+        """Daily digest type uses daily template."""
+        # Arrange
+        prepared = [
+            {
+                "title": "Test",
+                "source_name": "Test",
+                "ward_text": "",
+                "date_formatted": "Jan 1",
+                "summary": "",
+                "topics": [],
+                "newsletter_url": "http://test.com",
+                "matched_rules": [],
+            }
+        ]
+
+        # Act
+        html = _build_digest_html(
+            prepared,
+            DigestType.DAILY,
+            "http://prefs.com",
+            "http://unsub.com",
+        )
+
+        # Assert
+        self.assertIn("Daily Chicago Aldermen Newsletter Digest", html)
+        self.assertIn('class="newsletter"', html)
+
+    def test_uses_weekly_template_for_weekly_type(self):
+        """Weekly digest type uses weekly template."""
+        # Arrange
+        prepared = [
+            {
+                "topic": "bike_lanes",
+                "topic_display": "Bike Lanes",
+                "summary": "Summary",
+                "newsletter_count": 5,
+                "week_range": "Jan 1-7",
+                "week_id": "2026-W01",
+                "matched_rules": [],
+            }
+        ]
+
+        # Act
+        html = _build_digest_html(
+            prepared,
+            DigestType.WEEKLY,
+            "http://prefs.com",
+            "http://unsub.com",
+        )
+
+        # Assert
+        self.assertIn("Weekly Topic Digest", html)
+        self.assertIn('class="topic-report"', html)
+
+    def test_includes_preferences_and_unsubscribe_links(self):
+        """Footer includes both links."""
+        # Arrange
+        prepared = []
+
+        # Act
+        html = _build_digest_html(
+            prepared,
+            DigestType.DAILY,
+            "http://my-prefs.com",
+            "http://my-unsub.com",
+        )
+
+        # Assert
+        self.assertIn("http://my-prefs.com", html)
+        self.assertIn("http://my-unsub.com", html)
+
+
+class TestBuildDigestText(unittest.TestCase):
+    """Tests for unified _build_digest_text() function."""
+
+    def test_uses_daily_format_for_daily_type(self):
+        """Daily digest type uses daily text format."""
+        # Arrange
+        prepared = [
+            {
+                "title": "Test Newsletter",
+                "source_name": "Test",
+                "ward_text": "",
+                "date_formatted": "Jan 1",
+                "summary": "Summary",
+                "topics": ["bike_lanes"],
+                "newsletter_url": "http://test.com",
+                "matched_rules": ["Rule 1"],
+            }
+        ]
+
+        # Act
+        text = _build_digest_text(
+            prepared,
+            DigestType.DAILY,
+            "http://prefs.com",
+            "http://unsub.com",
+        )
+
+        # Assert
+        self.assertIn("DAILY NEWSLETTER DIGEST", text)
+        self.assertIn("1. Test Newsletter", text)
+        self.assertIn("Rule 1", text)
+
+    def test_uses_weekly_format_for_weekly_type(self):
+        """Weekly digest type uses weekly text format."""
+        # Arrange
+        prepared = [
+            {
+                "topic": "transit_funding",
+                "topic_display": "Public Transit",
+                "summary": "Transit summary",
+                "newsletter_count": 7,
+                "week_range": "Jan 1-7",
+                "week_id": "2026-W01",
+                "matched_rules": ["Transit Rule"],
+            }
+        ]
+
+        # Act
+        text = _build_digest_text(
+            prepared,
+            DigestType.WEEKLY,
+            "http://prefs.com",
+            "http://unsub.com",
+        )
+
+        # Assert
+        self.assertIn("WEEKLY TOPIC DIGEST", text)
+        self.assertIn("1. Public Transit", text)
+        self.assertIn("7 newsletters", text)
+        self.assertIn("Transit Rule", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_email_sender_digest_types.py
+++ b/backend/tests/unit/test_email_sender_digest_types.py
@@ -89,7 +89,7 @@ class TestSendDigest(unittest.TestCase):
         ]
         mock_resend.return_value = {"id": "email-456"}
 
-        notifications = [{"weekly_topic_reports": {}, "rule": {}}]
+        notifications = [{"report": {}, "rule": {}}]
 
         # Act
         result = send_digest(

--- a/backend/tests/unit/test_llm_processor.py
+++ b/backend/tests/unit/test_llm_processor.py
@@ -15,7 +15,6 @@ from processing.llm_processor import (
     score_relevance,
     extract_newsletter_metadata,
     TOPICS,
-    RETRY_TRUNCATE_THRESHOLD,
 )
 
 
@@ -61,38 +60,6 @@ class TestCallLLM(unittest.TestCase):
     @patch("processing.llm_processor.ollama_client")
     @patch("time.sleep")
     @patch("builtins.print")
-    def test_truncation_on_third_attempt(self, mock_print, mock_sleep, mock_client):
-        """Long prompt truncated on 3rd retry"""
-        long_prompt = "x" * 60000  # >50k chars
-        mock_response = Mock()
-        mock_response.message.content = '{"topics": []}'
-
-        # Fail twice, succeed on third attempt
-        mock_client.chat.side_effect = [
-            Exception("First failure"),
-            Exception("Second failure"),
-            mock_response,
-        ]
-
-        result = call_llm("test-model", long_prompt, {"type": "object"})
-
-        self.assertEqual(result, '{"topics": []}')
-        # Verify truncation message was printed
-        truncation_printed = any(
-            "Truncating prompt" in str(call) for call in mock_print.call_args_list
-        )
-        self.assertTrue(
-            truncation_printed, "Should print truncation message on 3rd attempt"
-        )
-
-        # On third attempt, prompt should be truncated
-        third_call = mock_client.chat.call_args_list[2]
-        prompt_used = third_call[1]["messages"][0]["content"]
-        self.assertEqual(len(prompt_used), RETRY_TRUNCATE_THRESHOLD)
-
-    @patch("processing.llm_processor.ollama_client")
-    @patch("time.sleep")
-    @patch("builtins.print")
     def test_max_retries_exceeded_raises(self, mock_print, mock_sleep, mock_client):
         """All retries fail, raises exception"""
         mock_client.chat.side_effect = Exception("Always fails")
@@ -103,8 +70,9 @@ class TestCallLLM(unittest.TestCase):
         self.assertIn("failed after 3 attempts", str(context.exception))
 
     @patch("processing.llm_processor.ollama_client")
+    @patch("time.sleep")
     @patch("builtins.print")
-    def test_empty_response_raises(self, mock_print, mock_client):
+    def test_empty_response_raises(self, mock_print, mock_sleep, mock_client):
         """Empty LLM response raises exception"""
         mock_response = Mock()
         mock_response.message.content = ""
@@ -116,8 +84,9 @@ class TestCallLLM(unittest.TestCase):
         self.assertIn("empty response", str(context.exception).lower())
 
     @patch("processing.llm_processor.ollama_client")
+    @patch("time.sleep")
     @patch("builtins.print")
-    def test_whitespace_only_response_raises(self, mock_print, mock_client):
+    def test_whitespace_only_response_raises(self, mock_print, mock_sleep, mock_client):
         """Whitespace-only response raises exception"""
         mock_response = Mock()
         mock_response.message.content = "   \n\t  "
@@ -421,7 +390,8 @@ class TestProcessWithOllama(unittest.TestCase):
     @patch("processing.llm_processor.extract_topics")
     @patch("processing.llm_processor.generate_summary")
     @patch("processing.llm_processor.score_relevance")
-    def test_full_pipeline(self, mock_score, mock_summary, mock_topics):
+    @patch("time.sleep")
+    def test_full_pipeline(self, mock_sleep, mock_score, mock_summary, mock_topics):
         """All three LLM steps execute successfully"""
         mock_topics.return_value = ["bike_lanes", "transit_funding"]
         mock_summary.return_value = "Newsletter about transit improvements."
@@ -445,7 +415,8 @@ class TestProcessWithOllama(unittest.TestCase):
 
     @patch("processing.llm_processor.extract_topics")
     @patch("builtins.print")
-    def test_truncation_applied(self, mock_print, mock_topics):
+    @patch("time.sleep")
+    def test_truncation_applied(self, mock_sleep, mock_print, mock_topics):
         """Content >100k chars truncated"""
         mock_topics.return_value = []
 
@@ -473,7 +444,10 @@ class TestProcessWithOllama(unittest.TestCase):
     @patch("processing.llm_processor.extract_topics")
     @patch("processing.llm_processor.generate_summary")
     @patch("processing.llm_processor.score_relevance")
-    def test_includes_todays_date(self, mock_score, mock_summary, mock_topics):
+    @patch("time.sleep")
+    def test_includes_todays_date(
+        self, mock_sleep, mock_score, mock_summary, mock_topics
+    ):
         """Prompt includes today's date"""
         mock_topics.return_value = []
         mock_summary.return_value = ""
@@ -498,8 +472,9 @@ class TestProcessWithOllama(unittest.TestCase):
     @patch("processing.llm_processor.generate_summary")
     @patch("processing.llm_processor.score_relevance")
     @patch("builtins.print")
+    @patch("time.sleep")
     def test_partial_failure_handling(
-        self, mock_print, mock_score, mock_summary, mock_topics
+        self, mock_sleep, mock_print, mock_score, mock_summary, mock_topics
     ):
         """One step fails, others continue"""
         # extract_topics, generate_summary, and score_relevance all catch their own
@@ -524,8 +499,9 @@ class TestProcessWithOllama(unittest.TestCase):
     @patch("processing.llm_processor.generate_summary")
     @patch("processing.llm_processor.score_relevance")
     @patch("builtins.print")
+    @patch("time.sleep")
     def test_returns_empty_on_complete_failure(
-        self, mock_print, mock_score, mock_summary, mock_topics
+        self, mock_sleep, mock_print, mock_score, mock_summary, mock_topics
     ):
         """All steps fail gracefully"""
         # The individual functions catch their own exceptions, so they return defaults
@@ -548,7 +524,10 @@ class TestProcessWithOllama(unittest.TestCase):
     @patch("processing.llm_processor.extract_topics")
     @patch("processing.llm_processor.generate_summary")
     @patch("processing.llm_processor.score_relevance")
-    def test_content_includes_subject(self, mock_score, mock_summary, mock_topics):
+    @patch("time.sleep")
+    def test_content_includes_subject(
+        self, mock_sleep, mock_score, mock_summary, mock_topics
+    ):
         """Content passed to LLM includes subject"""
         mock_topics.return_value = []
         mock_summary.return_value = ""
@@ -569,8 +548,9 @@ class TestProcessWithOllama(unittest.TestCase):
     @patch("processing.llm_processor.extract_topics")
     @patch("processing.llm_processor.generate_summary")
     @patch("processing.llm_processor.score_relevance")
+    @patch("time.sleep")
     def test_score_receives_topics_and_summary_context(
-        self, mock_score, mock_summary, mock_topics
+        self, mock_sleep, mock_score, mock_summary, mock_topics
     ):
         """Relevance scoring receives topics and summary as context"""
         mock_topics.return_value = ["bike_lanes"]

--- a/backend/tests/unit/test_llm_processor.py
+++ b/backend/tests/unit/test_llm_processor.py
@@ -13,7 +13,7 @@ from processing.llm_processor import (
     extract_topics,
     generate_summary,
     score_relevance,
-    process_with_ollama,
+    extract_newsletter_metadata,
     TOPICS,
     RETRY_TRUNCATE_THRESHOLD,
 )
@@ -416,7 +416,7 @@ class TestScoreRelevance(unittest.TestCase):
 
 
 class TestProcessWithOllama(unittest.TestCase):
-    """Tests for process_with_ollama() main pipeline function"""
+    """Tests for extract_newsletter_metadata() main pipeline function"""
 
     @patch("processing.llm_processor.extract_topics")
     @patch("processing.llm_processor.generate_summary")
@@ -432,7 +432,7 @@ class TestProcessWithOllama(unittest.TestCase):
             "plain_text": "New bike lanes and transit funding announced.",
         }
 
-        result = process_with_ollama(newsletter, "test-model")
+        result = extract_newsletter_metadata(newsletter, "test-model")
 
         self.assertEqual(result["topics"], ["bike_lanes", "transit_funding"])
         self.assertEqual(result["summary"], "Newsletter about transit improvements.")
@@ -456,7 +456,7 @@ class TestProcessWithOllama(unittest.TestCase):
             "plain_text": long_content,
         }
 
-        process_with_ollama(newsletter, "test-model", max_chars=100000)
+        extract_newsletter_metadata(newsletter, "test-model", max_chars=100000)
 
         # Verify truncation message was printed
         truncation_printed = any(
@@ -484,7 +484,7 @@ class TestProcessWithOllama(unittest.TestCase):
             "plain_text": "Test content",
         }
 
-        process_with_ollama(newsletter, "test-model")
+        extract_newsletter_metadata(newsletter, "test-model")
 
         # Check that content passed to extract_topics includes date
         call_args = mock_topics.call_args[0]
@@ -513,7 +513,7 @@ class TestProcessWithOllama(unittest.TestCase):
             "plain_text": "Content",
         }
 
-        result = process_with_ollama(newsletter, "test-model")
+        result = extract_newsletter_metadata(newsletter, "test-model")
 
         # Topics and score succeed, summary returns empty (as it does on error)
         self.assertEqual(result["topics"], ["bike_lanes"])
@@ -538,7 +538,7 @@ class TestProcessWithOllama(unittest.TestCase):
             "plain_text": "Content",
         }
 
-        result = process_with_ollama(newsletter, "test-model")
+        result = extract_newsletter_metadata(newsletter, "test-model")
 
         # All should return their error defaults
         self.assertEqual(result["topics"], [])
@@ -559,7 +559,7 @@ class TestProcessWithOllama(unittest.TestCase):
             "plain_text": "Newsletter body text",
         }
 
-        process_with_ollama(newsletter, "test-model")
+        extract_newsletter_metadata(newsletter, "test-model")
 
         # Check that subject was included in content
         call_args = mock_topics.call_args[0]
@@ -582,7 +582,7 @@ class TestProcessWithOllama(unittest.TestCase):
             "plain_text": "Content",
         }
 
-        process_with_ollama(newsletter, "test-model")
+        extract_newsletter_metadata(newsletter, "test-model")
 
         # Verify score_relevance was called with topics and summary
         self.assertEqual(mock_score.call_count, 1)

--- a/backend/tests/unit/test_notification_queue_digest_config.py
+++ b/backend/tests/unit/test_notification_queue_digest_config.py
@@ -1,0 +1,217 @@
+"""
+Unit tests for digest configuration system in process_notification_queue.py
+
+Tests DigestConfig, DIGEST_CONFIGS, and unified process_digests function.
+"""
+
+import unittest
+import sys
+import io
+from unittest.mock import patch, Mock
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from notifications.process_notification_queue import (
+    DIGEST_CONFIGS,
+    _calculate_daily_batch_id,
+    _calculate_weekly_batch_id,
+    process_digests,
+)
+from notifications.email_sender import DigestType
+
+
+class TestDigestConfig(unittest.TestCase):
+    """Tests for DigestConfig dataclass."""
+
+    def test_has_all_required_fields(self):
+        """DigestConfig contains all necessary configuration fields."""
+        # Arrange
+        config = DIGEST_CONFIGS[DigestType.DAILY]
+
+        # Assert
+        self.assertIsNotNone(config.digest_type)
+        self.assertIsNotNone(config.notification_type)
+        self.assertIsNotNone(config.delivery_type)
+        self.assertIsNotNone(config.batch_id_calculator)
+        self.assertIsNotNone(config.fetch_notifications)
+
+
+class TestDigestConfigs(unittest.TestCase):
+    """Tests for DIGEST_CONFIGS dictionary."""
+
+    def test_contains_daily_and_weekly_configs(self):
+        """Config exists for both digest types."""
+        self.assertIn(DigestType.DAILY, DIGEST_CONFIGS)
+        self.assertIn(DigestType.WEEKLY, DIGEST_CONFIGS)
+
+    def test_daily_config_values(self):
+        """Daily config has correct values."""
+        config = DIGEST_CONFIGS[DigestType.DAILY]
+
+        self.assertEqual(config.digest_type, DigestType.DAILY)
+        self.assertEqual(config.notification_type, "daily")
+        self.assertEqual(config.delivery_type, "daily_digest")
+
+    def test_weekly_config_values(self):
+        """Weekly config has correct values."""
+        config = DIGEST_CONFIGS[DigestType.WEEKLY]
+
+        self.assertEqual(config.digest_type, DigestType.WEEKLY)
+        self.assertEqual(config.notification_type, "weekly")
+        self.assertEqual(config.delivery_type, "weekly_digest")
+
+
+class TestCalculateDailyBatchId(unittest.TestCase):
+    """Tests for _calculate_daily_batch_id() function."""
+
+    @patch("notifications.process_notification_queue.datetime")
+    def test_returns_yesterday_in_chicago_time(self, mock_datetime):
+        """Returns yesterday's date in YYYY-MM-DD format (Chicago time)."""
+        # Arrange - Mock "today" as 2026-01-26 in Chicago
+        chicago_tz = ZoneInfo("America/Chicago")
+        mock_now = datetime(2026, 1, 26, 10, 0, 0, tzinfo=chicago_tz)
+        mock_datetime.now.return_value = mock_now
+
+        # Act
+        result = _calculate_daily_batch_id()
+
+        # Assert
+        self.assertEqual(result, "2026-01-25")
+        mock_datetime.now.assert_called_once_with(chicago_tz)
+
+
+class TestCalculateWeeklyBatchId(unittest.TestCase):
+    """Tests for _calculate_weekly_batch_id() function."""
+
+    @patch("notifications.process_notification_queue.datetime")
+    def test_returns_previous_week_in_iso_format(self, mock_datetime):
+        """Returns previous week ID in YYYY-WXX format."""
+        # Arrange - Mock "today" as 2026-01-26 (Monday of W05)
+        # Previous week is W04
+        chicago_tz = ZoneInfo("America/Chicago")
+        mock_now = datetime(2026, 1, 26, 10, 0, 0, tzinfo=chicago_tz)
+        mock_datetime.now.return_value = mock_now
+
+        # Act
+        result = _calculate_weekly_batch_id()
+
+        # Assert
+        self.assertEqual(result, "2026-W04")
+
+
+class TestProcessDigests(unittest.TestCase):
+    """Tests for unified process_digests() function."""
+
+    def setUp(self):
+        """Suppress print output during tests."""
+        self.held_output = io.StringIO()
+        sys.stdout = self.held_output
+
+    def tearDown(self):
+        """Restore stdout."""
+        sys.stdout = sys.__stdout__
+
+    @patch("notifications.process_notification_queue.send_digest")
+    @patch("notifications.process_notification_queue.get_supabase_client")
+    @patch("notifications.process_notification_queue.get_pending_notifications_by_user")
+    def test_processes_daily_digest(self, mock_get_notifs, mock_supabase, mock_send):
+        """Daily digest processed with correct configuration."""
+        # Arrange
+        mock_get_notifs.return_value = {
+            "user-1": [{"id": "notif-1", "newsletter_id": "nl-1", "rule_id": "rule-1"}]
+        }
+
+        mock_supabase_instance = Mock()
+        mock_supabase.return_value = mock_supabase_instance
+
+        # Mock user profile query
+        mock_profile_response = Mock()
+        mock_profile_response.data = {
+            "email": "test@example.com",
+            "notification_preferences": {"enabled": True},
+        }
+        mock_supabase_instance.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = mock_profile_response
+
+        # Mock update/insert operations
+        mock_supabase_instance.table.return_value.update.return_value.in_.return_value.execute.return_value = Mock()
+        mock_supabase_instance.table.return_value.insert.return_value.execute.return_value = Mock()
+
+        mock_send.return_value = {"success": True, "email_id": "email-123"}
+
+        # Act
+        result = process_digests(DigestType.DAILY, "2026-01-25", dry_run=False)
+
+        # Assert
+        self.assertEqual(result["sent"], 1)
+        mock_send.assert_called_once()
+
+        # Verify send_digest called with DAILY type
+        call_args = mock_send.call_args
+        self.assertEqual(call_args[0][3], DigestType.DAILY)
+
+    def test_weekly_config_exists(self):
+        """Weekly digest configuration exists and has correct values."""
+        # Just verify configuration exists and is correct
+        # Integration tests handle actual processing
+        config = DIGEST_CONFIGS[DigestType.WEEKLY]
+
+        self.assertEqual(config.digest_type, DigestType.WEEKLY)
+        self.assertEqual(config.notification_type, "weekly")
+        self.assertEqual(config.delivery_type, "weekly_digest")
+
+    @patch("notifications.process_notification_queue.get_pending_notifications_by_user")
+    def test_uses_default_batch_id_when_not_provided(self, mock_get_notifs):
+        """Calculates batch ID when not provided."""
+        # Arrange
+        mock_get_notifs.return_value = {}
+
+        # Act
+        with patch(
+            "notifications.process_notification_queue.datetime"
+        ) as mock_datetime:
+            from datetime import datetime as real_datetime
+            from zoneinfo import ZoneInfo
+
+            chicago_tz = ZoneInfo("America/Chicago")
+            mock_datetime.now.return_value = real_datetime(
+                2026, 1, 26, 10, 0, 0, tzinfo=chicago_tz
+            )
+            process_digests(DigestType.DAILY, batch_id=None, dry_run=True)
+
+        # Assert - should have calculated and used batch_id
+        mock_get_notifs.assert_called()
+
+    @patch("notifications.process_notification_queue.get_pending_notifications_by_user")
+    def test_dry_run_mode_does_not_send_emails(self, mock_get_notifs):
+        """Dry run mode counts but doesn't send."""
+        # Arrange
+        mock_get_notifs.return_value = {
+            "user-1": [{"id": "notif-1", "newsletter_id": "nl-1", "rule_id": "rule-1"}]
+        }
+
+        # Act
+        with patch("notifications.process_notification_queue.get_supabase_client"):
+            with patch(
+                "notifications.process_notification_queue.send_digest"
+            ) as mock_send:
+                result = process_digests(DigestType.DAILY, "2026-01-25", dry_run=True)
+
+        # Assert
+        self.assertEqual(result["sent"], 1)  # Counted
+        mock_send.assert_not_called()  # But not sent
+
+    def test_delivery_types_differ_by_config(self):
+        """Each digest type has unique delivery_type value."""
+        # Verify that daily and weekly have different delivery types
+        daily_config = DIGEST_CONFIGS[DigestType.DAILY]
+        weekly_config = DIGEST_CONFIGS[DigestType.WEEKLY]
+
+        self.assertNotEqual(
+            daily_config.delivery_type,
+            weekly_config.delivery_type,
+            "Daily and weekly should have different delivery types",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_polymorphic_notifications.py
+++ b/backend/tests/unit/test_polymorphic_notifications.py
@@ -1,0 +1,284 @@
+"""
+Unit tests for polymorphic notification queue functionality.
+
+Tests the ability of notification_queue to handle both newsletters (daily)
+and weekly topic reports (weekly) using dedicated newsletter_id and report_id columns.
+"""
+
+import sys
+import io
+import unittest
+from unittest.mock import patch, Mock
+from notifications.process_notification_queue import _extract_content_ids
+
+
+class TestExtractContentIds(unittest.TestCase):
+    """Tests for _extract_content_ids() helper function."""
+
+    def test_extracts_newsletter_ids_from_daily_notifications(self):
+        """Extracts newsletter_id from daily notifications."""
+        # Arrange
+        notifications = [
+            {"id": "notif-1", "newsletter_id": "nl-1", "rule_id": "rule-1"},
+            {"id": "notif-2", "newsletter_id": "nl-2", "rule_id": "rule-1"},
+        ]
+
+        # Act
+        result = _extract_content_ids(notifications)
+
+        # Assert
+        self.assertEqual(len(result), 2)
+        self.assertIn("nl-1", result)
+        self.assertIn("nl-2", result)
+
+    def test_extracts_report_ids_from_weekly_notifications(self):
+        """Extracts report_id from weekly notifications."""
+        # Arrange
+        notifications = [
+            {"id": "notif-1", "report_id": "report-1", "rule_id": "rule-1"},
+            {"id": "notif-2", "report_id": "report-2", "rule_id": "rule-1"},
+        ]
+
+        # Act
+        result = _extract_content_ids(notifications)
+
+        # Assert
+        self.assertEqual(len(result), 2)
+        self.assertIn("report-1", result)
+        self.assertIn("report-2", result)
+
+    def test_handles_mixed_notifications_with_none_values(self):
+        """Handles notifications with None values for unused ID field."""
+        # Arrange - Weekly notification has newsletter_id=None
+        notifications = [
+            {
+                "id": "notif-1",
+                "newsletter_id": "nl-1",
+                "report_id": None,
+                "rule_id": "rule-1",
+            },
+            {
+                "id": "notif-2",
+                "newsletter_id": None,
+                "report_id": "report-1",
+                "rule_id": "rule-2",
+            },
+        ]
+
+        # Act
+        result = _extract_content_ids(notifications)
+
+        # Assert
+        self.assertEqual(len(result), 2)
+        self.assertIn("nl-1", result)
+        self.assertIn("report-1", result)
+
+    def test_deduplicates_identical_ids(self):
+        """Returns unique IDs when multiple notifications reference same content."""
+        # Arrange
+        notifications = [
+            {"id": "notif-1", "newsletter_id": "nl-1", "rule_id": "rule-1"},
+            {"id": "notif-2", "newsletter_id": "nl-1", "rule_id": "rule-2"},
+            {"id": "notif-3", "newsletter_id": "nl-2", "rule_id": "rule-1"},
+        ]
+
+        # Act
+        result = _extract_content_ids(notifications)
+
+        # Assert
+        self.assertEqual(len(result), 2)
+        self.assertIn("nl-1", result)
+        self.assertIn("nl-2", result)
+
+    def test_handles_empty_list(self):
+        """Returns empty list when given empty notifications."""
+        # Act
+        result = _extract_content_ids([])
+
+        # Assert
+        self.assertEqual(result, [])
+
+    def test_skips_notifications_missing_both_ids(self):
+        """Gracefully handles malformed notifications missing both IDs."""
+        # Arrange - Edge case that shouldn't happen due to DB constraint
+        notifications = [
+            {"id": "notif-1", "newsletter_id": "nl-1", "rule_id": "rule-1"},
+            {"id": "notif-bad", "rule_id": "rule-2"},  # Missing both IDs
+        ]
+
+        # Act
+        result = _extract_content_ids(notifications)
+
+        # Assert
+        self.assertEqual(len(result), 1)
+        self.assertIn("nl-1", result)
+
+
+class TestWeeklyNotificationQueuing(unittest.TestCase):
+    """Tests for weekly notification queuing with report_id."""
+
+    def setUp(self):
+        """Suppress print output during tests."""
+        self.held_output = io.StringIO()
+        sys.stdout = self.held_output
+
+    def tearDown(self):
+        """Restore stdout."""
+        sys.stdout = sys.__stdout__
+
+    @patch("notifications.weekly_notification_queue.get_supabase_client")
+    def test_queues_with_report_id_column(self, mock_get_client):
+        """Weekly notifications use report_id column, not newsletter_id."""
+        from notifications.weekly_notification_queue import queue_weekly_notifications
+
+        # Arrange
+        mock_supabase = Mock()
+        mock_get_client.return_value = mock_supabase
+
+        # Mock users with weekly rules
+        mock_rules_response = Mock()
+        mock_rules_response.data = [
+            {"id": "rule-1", "user_id": "user-1", "topics": ["bike_lanes"]},
+        ]
+
+        # Mock user profiles (notifications enabled)
+        mock_profiles_response = Mock()
+        mock_profiles_response.data = [
+            {
+                "id": "user-1",
+                "notification_preferences": {"enabled": True},
+            }
+        ]
+
+        # Mock reports for the week
+        mock_reports_response = Mock()
+        mock_reports_response.data = [
+            {"id": "report-1", "topic": "bike_lanes", "week_id": "2026-W05"}
+        ]
+
+        # Track insert calls
+        insert_calls = []
+
+        # Setup mock chain for multiple queries
+        def table_side_effect(table_name):
+            if table_name == "notification_rules":
+                return Mock(
+                    select=Mock(
+                        return_value=Mock(
+                            eq=Mock(
+                                return_value=Mock(
+                                    eq=Mock(
+                                        return_value=Mock(
+                                            execute=Mock(
+                                                return_value=mock_rules_response
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            elif table_name == "user_profiles":
+                return Mock(
+                    select=Mock(
+                        return_value=Mock(
+                            in_=Mock(
+                                return_value=Mock(
+                                    execute=Mock(return_value=mock_profiles_response)
+                                )
+                            )
+                        )
+                    )
+                )
+            elif table_name == "weekly_topic_reports":
+                return Mock(
+                    select=Mock(
+                        return_value=Mock(
+                            eq=Mock(
+                                return_value=Mock(
+                                    execute=Mock(return_value=mock_reports_response)
+                                )
+                            )
+                        )
+                    )
+                )
+            elif table_name == "notification_queue":
+                # Mock insert and track calls
+                def track_insert(data):
+                    insert_calls.append(data)
+                    return Mock(execute=Mock(return_value=Mock()))
+
+                return Mock(insert=track_insert)
+
+        mock_supabase.table.side_effect = table_side_effect
+
+        # Act
+        result = queue_weekly_notifications("2026-W05")
+
+        # Assert
+        self.assertEqual(result["queued"], 1)
+        self.assertEqual(len(insert_calls), 1, "Should have one insert call")
+
+        # Verify the inserted data uses report_id
+        inserted_data = insert_calls[0]
+        self.assertIn("report_id", inserted_data)
+        self.assertEqual(inserted_data["report_id"], "report-1")
+        self.assertNotIn("newsletter_id", inserted_data)
+
+
+class TestWeeklyNotificationFetching(unittest.TestCase):
+    """Tests for fetching weekly notifications with proper joins."""
+
+    @patch("notifications.process_notification_queue.get_supabase_client")
+    def test_fetches_with_report_join(self, mock_get_client):
+        """Weekly notification fetching joins to weekly_topic_reports via report_id."""
+        from notifications.process_notification_queue import _fetch_weekly_notifications
+
+        # Arrange
+        mock_supabase = Mock()
+        mock_get_client.return_value = mock_supabase
+
+        mock_response = Mock()
+        mock_response.data = [
+            {
+                "id": "notif-1",
+                "user_id": "user-1",
+                "report_id": "report-1",
+                "rule_id": "rule-1",
+                "report": {
+                    "id": "report-1",
+                    "topic": "bike_lanes",
+                    "week_id": "2026-W05",
+                    "report_summary": "Test summary",
+                    "newsletter_ids": ["nl-1", "nl-2"],
+                },
+                "rule": {"name": "Test Rule"},
+            }
+        ]
+
+        # Setup mock chain
+        mock_supabase.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value = mock_response
+
+        # Act
+        result = _fetch_weekly_notifications("2026-W05")
+
+        # Assert
+        self.assertEqual(len(result), 1)
+        self.assertIn("user-1", result)
+        self.assertEqual(len(result["user-1"]), 1)
+
+        notification = result["user-1"][0]
+        self.assertEqual(notification["report_id"], "report-1")
+        self.assertIn("report", notification)
+        self.assertEqual(notification["report"]["topic"], "bike_lanes")
+
+        # Verify select used report_id and joined to weekly_topic_reports
+        select_call = mock_supabase.table.return_value.select.call_args
+        select_string = select_call[0][0]
+        self.assertIn("report_id", select_string)
+        self.assertIn("report:weekly_topic_reports", select_string)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_prevent_empty_digests.py
+++ b/backend/tests/unit/test_prevent_empty_digests.py
@@ -1,0 +1,120 @@
+"""
+Unit tests for preventing empty digest emails.
+
+Tests that send_digest returns an error when no content is available after
+preparation, and that process_digests handles this error by skipping.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+from notifications.email_sender import send_digest, DigestType
+from notifications.process_notification_queue import process_digests
+
+
+class TestPreventEmptyDigests(unittest.TestCase):
+    """Tests for empty digest prevention logic."""
+
+    @patch("notifications.email_sender._prepare_newsletter_data")
+    @patch("notifications.email_sender._build_unsubscribe_url")
+    def test_send_digest_empty_daily(self, mock_unsub, mock_prepare):
+        """send_digest returns error when daily preparation results in no content."""
+        # Arrange
+        mock_prepare.return_value = []
+        mock_unsub.return_value = "https://example.com/unsub"
+        notifications = [{"id": "notif_1", "newsletter_id": "nl_1"}]
+
+        # Act
+        result = send_digest(
+            user_id="user_123",
+            user_email="test@example.com",
+            notifications=notifications,
+            digest_type=DigestType.DAILY,
+        )
+
+        # Assert
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Empty digest content")
+        mock_prepare.assert_called_once()
+
+    @patch("notifications.email_sender._prepare_weekly_report_data")
+    @patch("notifications.email_sender._build_unsubscribe_url")
+    def test_send_digest_empty_weekly(self, mock_unsub, mock_prepare):
+        """send_digest returns error when weekly preparation results in no content."""
+        # Arrange
+        mock_prepare.return_value = []
+        mock_unsub.return_value = "https://example.com/unsub"
+        notifications = [{"id": "notif_1", "report_id": "rep_1"}]
+
+        # Act
+        result = send_digest(
+            user_id="user_123",
+            user_email="test@example.com",
+            notifications=notifications,
+            digest_type=DigestType.WEEKLY,
+        )
+
+        # Assert
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Empty digest content")
+        mock_prepare.assert_called_once()
+
+    @patch("builtins.print")
+    @patch("notifications.process_notification_queue.get_supabase_client")
+    @patch("notifications.process_notification_queue.send_digest")
+    def test_process_digests_handles_empty_result(
+        self, mock_send, mock_supabase, mock_print
+    ):
+        """process_digests increments skipped stat and updates DB for empty content."""
+        # Arrange
+        mock_sb = MagicMock()
+        mock_supabase.return_value = mock_sb
+
+        # Mock notifications by user fetch
+        config_mock = MagicMock()
+        config_mock.fetch_notifications.return_value = {
+            "user_123": [
+                {"id": "notif_1", "rule_id": "rule_1", "newsletter_id": "nl_1"}
+            ]
+        }
+        config_mock.batch_id_calculator.return_value = "2026-01-31"
+        config_mock.digest_type = DigestType.DAILY
+        config_mock.delivery_type = "daily_digest"
+
+        # Mock user profile fetch
+        mock_sb.table().select().eq().single().execute.return_value.data = {
+            "email": "test@example.com",
+            "notification_preferences": {"enabled": True},
+        }
+
+        # Mock send_digest to return empty error
+        mock_send.return_value = {"success": False, "error": "Empty digest content"}
+
+        # Patch the DIGEST_CONFIGS to use our mock
+        with patch(
+            "notifications.process_notification_queue.DIGEST_CONFIGS",
+            {DigestType.DAILY: config_mock},
+        ):
+            # Act
+            stats = process_digests(DigestType.DAILY, batch_id="2026-01-31")
+
+            # Assert
+            self.assertEqual(stats["skipped"], 1)
+            self.assertEqual(stats["sent"], 0)
+            self.assertEqual(stats["failed"], 0)
+
+            # Verify notification_queue was updated with error
+            mock_sb.table.assert_any_call("notification_queue")
+            mock_sb.table().update.assert_called_with(
+                {"status": "failed", "error_message": "Empty digest content"}
+            )
+
+            # Verify notification_history was recorded
+            mock_sb.table.assert_any_call("notification_history")
+            mock_sb.table().insert.assert_called()
+            history_data = mock_sb.table().insert.call_args[0][0]
+            self.assertEqual(history_data["success"], False)
+            self.assertEqual(history_data["error_message"], "Empty digest content")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_process_llm_metadata.py
+++ b/backend/tests/unit/test_process_llm_metadata.py
@@ -99,7 +99,7 @@ class TestFetchNewsletters(unittest.TestCase):
 class TestNotificationQueuing(unittest.TestCase):
     """Test notification queuing during LLM processing."""
 
-    @patch("utils.process_llm_metadata.process_with_ollama")
+    @patch("utils.process_llm_metadata.extract_newsletter_metadata")
     @patch("notifications.rule_matcher.match_newsletter_to_rules")
     @patch("notifications.rule_matcher.queue_notifications")
     def test_queues_notifications_when_flag_enabled(
@@ -153,7 +153,7 @@ class TestNotificationQueuing(unittest.TestCase):
         mock_match.assert_called_once()
         mock_queue.assert_called_once()
 
-    @patch("utils.process_llm_metadata.process_with_ollama")
+    @patch("utils.process_llm_metadata.extract_newsletter_metadata")
     def test_skips_notifications_when_flag_disabled(self, mock_llm):
         """Test notifications not queued when --queue-notifications not set."""
         # Arrange

--- a/backend/tests/unit/test_weekly_newsletter_references.py
+++ b/backend/tests/unit/test_weekly_newsletter_references.py
@@ -1,0 +1,174 @@
+"""
+Unit tests for referenced newsletters in weekly digest emails.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from notifications.email_sender import (
+    _fetch_newsletter_details,
+    _prepare_weekly_report_data,
+    _render_weekly_content_html,
+    _render_weekly_content_text,
+)
+
+
+class TestFetchNewsletterDetails(unittest.TestCase):
+    """Tests for _fetch_newsletter_details() function."""
+
+    @patch("notifications.email_sender.get_supabase_client")
+    def test_fetches_and_sorts_by_ward(self, mock_get_client):
+        """Fetches newsletter details and sorts by ward number."""
+        # Arrange
+        mock_supabase = MagicMock()
+        mock_get_client.return_value = mock_supabase
+
+        mock_response = MagicMock()
+        mock_response.data = [
+            {
+                "id": "nl-3",
+                "subject": "Ward 48 Newsletter",
+                "received_date": "2026-01-24T00:00:00Z",
+                "source": {"ward_number": 48},
+            },
+            {
+                "id": "nl-1",
+                "subject": "Ward 40 Newsletter",
+                "received_date": "2026-01-20T00:00:00Z",
+                "source": {"ward_number": 40},
+            },
+            {
+                "id": "nl-2",
+                "subject": "Ward 43 Newsletter",
+                "received_date": "2026-01-22T00:00:00Z",
+                "source": {"ward_number": 43},
+            },
+        ]
+
+        mock_supabase.table.return_value.select.return_value.in_.return_value.execute.return_value = mock_response
+
+        # Act
+        result = _fetch_newsletter_details(["nl-1", "nl-2", "nl-3"])
+
+        # Assert
+        self.assertEqual(len(result), 3)
+        # Should be sorted by ward number
+        self.assertEqual(result[0]["ward_number"], 40)
+        self.assertEqual(result[1]["ward_number"], 43)
+        self.assertEqual(result[2]["ward_number"], 48)
+
+    @patch("notifications.email_sender.get_supabase_client")
+    def test_handles_empty_list(self, mock_get_client):
+        """Returns empty list for empty input."""
+        result = _fetch_newsletter_details([])
+        self.assertEqual(result, [])
+
+
+class TestPrepareWeeklyReportData(unittest.TestCase):
+    """Tests for _prepare_weekly_report_data() with newsletter references."""
+
+    @patch("notifications.email_sender._fetch_newsletter_details")
+    def test_includes_referenced_newsletters(self, mock_fetch):
+        """Prepared data includes referenced newsletters."""
+        # Arrange
+        mock_fetch.return_value = [
+            {
+                "id": "nl-1",
+                "subject": "Test Newsletter",
+                "received_date": "2026-01-20T00:00:00Z",
+                "ward_number": 40,
+            }
+        ]
+
+        notifications = [
+            {
+                "report": {
+                    "topic": "bike_lanes",
+                    "week_id": "2026-W04",
+                    "report_summary": "Test summary",
+                    "newsletter_ids": ["nl-1"],
+                },
+                "rule": {"name": "Test Rule"},
+            }
+        ]
+
+        # Act
+        result = _prepare_weekly_report_data(notifications)
+
+        # Assert
+        self.assertEqual(len(result), 1)
+        self.assertIn("referenced_newsletters", result[0])
+        self.assertEqual(len(result[0]["referenced_newsletters"]), 1)
+        self.assertEqual(result[0]["referenced_newsletters"][0]["id"], "nl-1")
+
+
+class TestRenderWeeklyContentWithReferences(unittest.TestCase):
+    """Tests for weekly content rendering with newsletter references."""
+
+    def test_html_includes_referenced_section(self):
+        """HTML output includes referenced newsletters section."""
+        # Arrange
+        prepared = [
+            {
+                "topic": "bike_lanes",
+                "topic_display": "Bike Lanes",
+                "summary": "Test summary",
+                "newsletter_count": 1,
+                "week_range": "Jan 20-26",
+                "week_id": "2026-W04",
+                "matched_rules": ["Test Rule"],
+                "referenced_newsletters": [
+                    {
+                        "id": "nl-1",
+                        "subject": "Ward 40 Updates",
+                        "received_date": "2026-01-20T00:00:00Z",
+                        "ward_number": 40,
+                    }
+                ],
+            }
+        ]
+
+        # Act
+        html = _render_weekly_content_html(prepared)
+
+        # Assert
+        self.assertIn("Referenced newsletters:", html)
+        self.assertIn("Ward 40:", html)
+        self.assertIn("Ward 40 Updates", html)
+        self.assertIn("/newsletter/nl-1", html)
+
+    def test_text_includes_referenced_section(self):
+        """Plain text output includes referenced newsletters section."""
+        # Arrange
+        prepared = [
+            {
+                "topic": "bike_lanes",
+                "topic_display": "Bike Lanes",
+                "summary": "Test summary",
+                "newsletter_count": 1,
+                "week_range": "Jan 20-26",
+                "week_id": "2026-W04",
+                "matched_rules": ["Test Rule"],
+                "referenced_newsletters": [
+                    {
+                        "id": "nl-1",
+                        "subject": "Ward 40 Updates",
+                        "received_date": "2026-01-20T00:00:00Z",
+                        "ward_number": 40,
+                    }
+                ],
+            }
+        ]
+
+        # Act
+        text = _render_weekly_content_text(prepared)
+
+        # Assert
+        self.assertIn("Referenced newsletters:", text)
+        self.assertIn("Ward 40:", text)
+        self.assertIn("Ward 40 Updates", text)
+        self.assertIn("/newsletter/nl-1", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_weekly_report_generator.py
+++ b/backend/tests/unit/test_weekly_report_generator.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for processing/weekly_report_generator.py
+
+Tests actual business logic: aggregation, error handling, and resilience.
+Only includes tests that verify real functionality, not trivial language features.
+"""
+
+import unittest
+import sys
+import io
+from unittest.mock import patch
+from processing.weekly_report_generator import (
+    extract_facts_from_newsletters,
+    synthesize_weekly_summary,
+)
+from models.weekly_report import KeyDevelopment
+
+
+class TestExtractFactsFromNewsletters(unittest.TestCase):
+    """Tests for extract_facts_from_newsletters() aggregation."""
+
+    def setUp(self):
+        """Suppress print output."""
+        self.held_output = io.StringIO()
+        sys.stdout = self.held_output
+
+    def tearDown(self):
+        """Restore stdout."""
+        sys.stdout = sys.__stdout__
+
+    @patch("processing.weekly_report_generator.extract_facts_from_single_newsletter")
+    def test_aggregates_facts_from_multiple_newsletters(self, mock_extract):
+        """Facts from multiple newsletters aggregated into single list."""
+        # Arrange
+        dev1 = KeyDevelopment(
+            description="Dev from NL1", newsletter_ids=["nl-1"], wards=["10"]
+        )
+        dev2 = KeyDevelopment(
+            description="Dev from NL2", newsletter_ids=["nl-2"], wards=["20"]
+        )
+        mock_extract.side_effect = [[dev1], [dev2]]
+
+        newsletters = [
+            {"id": "nl-1", "subject": "NL1", "plain_text": "C1", "source_name": "S1"},
+            {"id": "nl-2", "subject": "NL2", "plain_text": "C2", "source_name": "S2"},
+        ]
+
+        # Act
+        result = extract_facts_from_newsletters("bike_lanes", newsletters)
+
+        # Assert
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].description, "Dev from NL1")
+        self.assertEqual(result[1].description, "Dev from NL2")
+
+    @patch("processing.weekly_report_generator.extract_facts_from_single_newsletter")
+    def test_continues_on_individual_failure(self, mock_extract):
+        """Processing continues if one newsletter fails (resilience)."""
+        # Arrange
+        dev1 = KeyDevelopment(description="Success", newsletter_ids=["nl-1"], wards=[])
+        mock_extract.side_effect = [[], [dev1], []]  # Only middle succeeds
+
+        newsletters = [
+            {"id": "nl-1", "subject": "NL1", "plain_text": "C1", "source_name": "S1"},
+            {"id": "nl-2", "subject": "NL2", "plain_text": "C2", "source_name": "S2"},
+            {"id": "nl-3", "subject": "NL3", "plain_text": "C3", "source_name": "S3"},
+        ]
+
+        # Act
+        result = extract_facts_from_newsletters("city_budget", newsletters)
+
+        # Assert
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].description, "Success")
+        # All 3 were attempted despite failures
+        self.assertEqual(mock_extract.call_count, 3)
+
+
+class TestSynthesizeWeeklySummary(unittest.TestCase):
+    """Tests for synthesize_weekly_summary() function."""
+
+    def setUp(self):
+        """Suppress print output."""
+        self.held_output = io.StringIO()
+        sys.stdout = self.held_output
+
+    def tearDown(self):
+        """Restore stdout."""
+        sys.stdout = sys.__stdout__
+
+    @patch("processing.weekly_report_generator.call_llm")
+    def test_synthesizes_facts_into_summary(self, mock_llm):
+        """Multiple facts synthesized into narrative using LLM."""
+        # Arrange
+        mock_llm.return_value = (
+            '{"summary": "This week saw significant bike lane developments."}'
+        )
+
+        facts = [
+            KeyDevelopment(
+                description="Ward 10 approved bike lanes",
+                newsletter_ids=["nl-1"],
+                wards=["10"],
+            ),
+            KeyDevelopment(
+                description="Ward 20 announced bike lane study",
+                newsletter_ids=["nl-2"],
+                wards=["20"],
+            ),
+        ]
+
+        # Act
+        result = synthesize_weekly_summary("bike_lanes", facts, "2026-W05")
+
+        # Assert
+        self.assertIn("significant bike lane", result)
+        mock_llm.assert_called_once()
+
+    @patch("processing.weekly_report_generator.call_llm")
+    def test_handles_synthesis_failure_gracefully(self, mock_llm):
+        """Returns empty string on LLM failure instead of crashing."""
+        # Arrange
+        mock_llm.side_effect = Exception("LLM timeout")
+
+        facts = [
+            KeyDevelopment(description="Test", newsletter_ids=["nl-1"], wards=["10"])
+        ]
+
+        # Act
+        result = synthesize_weekly_summary("bike_lanes", facts, "2026-W05")
+
+        # Assert
+        self.assertEqual(result, "")  # Graceful degradation
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/utils/preview_weekly_digest.py
+++ b/backend/utils/preview_weekly_digest.py
@@ -1,0 +1,270 @@
+"""
+Preview weekly digest email output.
+
+Generates complete HTML and plain text email previews for a weekly digest
+to validate formatting and content before sending.
+
+Usage:
+    # Preview with real data from database
+    uv run python -m utils.preview_weekly_digest --topic bike_lanes --week 2026-W04
+
+    # Preview with sample data
+    uv run python -m utils.preview_weekly_digest --sample
+
+    # Save output to files
+    uv run python -m utils.preview_weekly_digest --topic bike_lanes --week 2026-W04 --save
+"""
+
+import argparse
+from typing import Any
+
+from notifications.email_sender import (
+    DigestType,
+    _build_digest_html,
+    _build_digest_text,
+    _fetch_newsletter_details,
+    _format_topic_name,
+    _format_week_range,
+)
+from shared.db import get_supabase_client
+
+
+def fetch_weekly_report(topic: str, week_id: str) -> dict[str, Any] | None:
+    """
+    Fetch a weekly report from the database.
+
+    Args:
+        topic: Topic identifier (e.g., "bike_lanes")
+        week_id: Week identifier (YYYY-WXX)
+
+    Returns:
+        Report dict or None if not found
+    """
+    supabase = get_supabase_client()
+
+    try:
+        response = (
+            supabase.table("weekly_topic_reports")
+            .select("*")
+            .eq("topic", topic)
+            .eq("week_id", week_id)
+            .single()
+            .execute()
+        )
+
+        if not response.data:
+            print(f"✗ No report found for {topic} / {week_id}")
+            return None
+
+        return dict(response.data)  # type: ignore
+
+    except Exception as e:
+        print(f"✗ Error fetching report: {e}")
+        return None
+
+
+def get_sample_report() -> dict[str, Any]:
+    """Get sample report data for testing."""
+    return {
+        "topic": "bike_lanes",
+        "week_id": "2026-W04",
+        "report_summary": """In the 40th Ward, concrete bike medians were completed along Pratt Boulevard, with signage installation and striping modifications pending. CDOT also temporarily closed the northern turning lane on Lincoln Avenue between Ainslie and Western to install new traffic lights and adjust signal timing for improved bike lane alignment.
+
+The 43rd Ward introduced new enforcement tools, with the Department of Finance adding "Vehicle Parked in Bike Lane" as a reportable offense through 311, the CHI311 app, and the 311 website. CDOT also updated guidance on scooter and e-bike use, clarifying how these modes interact with bike lanes.
+
+In the 48th Ward, CDOT installed new bike racks on the 5600 block of North Kenmore and launched the Bike Chicago program, offering 5,000 free bicycles with safety and maintenance equipment to eligible Chicagoans.""",
+        "newsletter_ids": [
+            "98d9f7a0-8d3a-43ce-ac09-c31e4287bd6e",
+            "f32c50a1-3402-4cfe-9f26-739d83942885",
+            "976ac29c-ac71-4b8b-8965-f7b80e4be47d",
+        ],
+    }
+
+
+def get_sample_newsletters() -> list[dict[str, Any]]:
+    """Get sample newsletter data for testing."""
+    return [
+        {
+            "id": "98d9f7a0-8d3a-43ce-ac09-c31e4287bd6e",
+            "subject": "Pratt Boulevard Bike Lane Updates",
+            "received_date": "2026-01-20T12:00:00Z",
+            "ward_number": 40,
+        },
+        {
+            "id": "f32c50a1-3402-4cfe-9f26-739d83942885",
+            "subject": "New Bike Lane Parking Enforcement Tools",
+            "received_date": "2026-01-22T14:30:00Z",
+            "ward_number": 43,
+        },
+        {
+            "id": "976ac29c-ac71-4b8b-8965-f7b80e4be47d",
+            "subject": "Bike Infrastructure and Access Improvements",
+            "received_date": "2026-01-24T10:15:00Z",
+            "ward_number": 48,
+        },
+    ]
+
+
+def prepare_report_for_preview(
+    report: dict[str, Any], use_sample_newsletters: bool = False
+) -> list[dict[str, Any]]:
+    """
+    Prepare report data in the format expected by email templates.
+
+    Args:
+        report: Report dict from database or sample
+        use_sample_newsletters: If True, use sample newsletter data instead of fetching
+
+    Returns:
+        List containing single prepared report dict
+    """
+    topic = report["topic"]
+    week_id = report["week_id"]
+    newsletter_ids = report.get("newsletter_ids", [])
+
+    # Fetch or use sample newsletter details
+    if use_sample_newsletters:
+        referenced_newsletters = get_sample_newsletters()
+    else:
+        referenced_newsletters = _fetch_newsletter_details(newsletter_ids)
+
+    # Format data
+    topic_display = _format_topic_name(topic)
+    week_range = _format_week_range(week_id)
+    newsletter_count = len(newsletter_ids)
+
+    return [
+        {
+            "topic": topic,
+            "topic_display": topic_display,
+            "summary": report.get("report_summary", ""),
+            "newsletter_count": newsletter_count,
+            "week_range": week_range,
+            "week_id": week_id,
+            "matched_rules": ["Test Rule"],  # Sample rule for preview
+            "referenced_newsletters": referenced_newsletters,
+        }
+    ]
+
+
+def preview_digest(
+    prepared_reports: list[dict[str, Any]], save_files: bool = False
+) -> None:
+    """
+    Generate and display/save email preview.
+
+    Args:
+        prepared_reports: List of prepared report dicts
+        save_files: If True, save HTML and text to files
+    """
+    # Sample URLs
+    preferences_url = "https://example.com/preferences"
+    unsubscribe_url = "https://example.com/unsubscribe?token=xxx"
+
+    # Generate HTML and text
+    html_output = _build_digest_html(
+        prepared_reports, DigestType.WEEKLY, preferences_url, unsubscribe_url
+    )
+    text_output = _build_digest_text(
+        prepared_reports, DigestType.WEEKLY, preferences_url, unsubscribe_url
+    )
+
+    if save_files:
+        # Save to files
+        html_file = "weekly_digest_preview.html"
+        text_file = "weekly_digest_preview.txt"
+
+        with open(html_file, "w", encoding="utf-8") as f:
+            f.write(html_output)
+
+        with open(text_file, "w", encoding="utf-8") as f:
+            f.write(text_output)
+
+        print(f"\nSaved HTML preview to: {html_file}")
+        print(f"Saved text preview to: {text_file}")
+        print(f"\nOpen {html_file} in a browser to view the formatted email.")
+
+    else:
+        # Print to console
+        print("\n" + "=" * 80)
+        print("HTML EMAIL PREVIEW")
+        print("=" * 80)
+        print(html_output)
+
+        print("\n" + "=" * 80)
+        print("PLAIN TEXT EMAIL PREVIEW")
+        print("=" * 80)
+        print(text_output)
+
+    # Print stats
+    print("\n" + "=" * 80)
+    print("STATS")
+    print("=" * 80)
+    print(f"HTML length: {len(html_output)} characters")
+    print(f"Text length: {len(text_output)} characters")
+    print(f"Reports: {len(prepared_reports)}")
+    if prepared_reports:
+        print(
+            f"Referenced newsletters: {len(prepared_reports[0].get('referenced_newsletters', []))}"
+        )
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Preview weekly digest email output")
+
+    parser.add_argument(
+        "--topic",
+        type=str,
+        help="Topic to preview (e.g., bike_lanes)",
+    )
+
+    parser.add_argument(
+        "--week",
+        type=str,
+        help="Week ID (YYYY-WXX format)",
+    )
+
+    parser.add_argument(
+        "--sample",
+        action="store_true",
+        help="Use sample data instead of fetching from database",
+    )
+
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="Save output to HTML and text files instead of printing to console",
+    )
+
+    args = parser.parse_args()
+
+    # Get report data
+    if args.sample:
+        print("Using sample data for preview...")
+        report = get_sample_report()
+        prepared_reports = prepare_report_for_preview(
+            report, use_sample_newsletters=True
+        )
+    else:
+        if not args.topic or not args.week:
+            print("✗ Error: --topic and --week required unless using --sample")
+            parser.print_help()
+            exit(1)
+
+        print(f"Fetching report for {args.topic} / {args.week}...")
+        fetched_report = fetch_weekly_report(args.topic, args.week)
+        if not fetched_report:
+            exit(1)
+
+        print("✓ Report found, preparing preview...")
+        prepared_reports = prepare_report_for_preview(
+            fetched_report, use_sample_newsletters=False
+        )
+
+    # Generate preview
+    preview_digest(prepared_reports, save_files=args.save)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/utils/process_llm_metadata.py
+++ b/backend/utils/process_llm_metadata.py
@@ -35,7 +35,7 @@ import argparse
 from typing import Any, cast
 from dotenv import load_dotenv
 from shared.db import get_supabase_client
-from processing.llm_processor import process_with_ollama
+from processing.llm_processor import extract_newsletter_metadata
 
 load_dotenv()
 
@@ -103,7 +103,7 @@ def reprocess_newsletter(
 
     try:
         # Run LLM processing
-        llm_data = process_with_ollama(newsletter, model)
+        llm_data = extract_newsletter_metadata(newsletter, model)
 
         # Update database
         update_result = (

--- a/backend/utils/process_weekly_reports.py
+++ b/backend/utils/process_weekly_reports.py
@@ -19,13 +19,19 @@ Usage:
 """
 
 import argparse
+import os
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
+from dotenv import load_dotenv
 
 from models.weekly_report import WeeklyTopicReport
 from notifications.error_logger import log_notification_error
 from processing.weekly_report_generator import generate_weekly_topic_report
 from shared.db import get_supabase_client
+
+load_dotenv()
+
+ENABLE_LLM = os.getenv("ENABLE_LLM", "false").lower() == "true"
 
 
 def get_iso_week_id(date: datetime | None = None) -> str:
@@ -200,7 +206,13 @@ def process_weekly_reports(
     print(f"Mode: {'DRY RUN' if dry_run else 'PRODUCTION'}")
     print(f"Force: {'Yes' if force else 'No'}")
     print(f"Model: {model}")
+    print(f"LLM Enabled: {'Yes' if ENABLE_LLM else 'No'}")
     print()
+
+    if not ENABLE_LLM:
+        print("ℹ ENABLE_LLM is false. Skipping report generation.")
+        print("  Existing reports will still be processed by the notification queue.")
+        return {"generated": 0, "skipped": 0, "failed": 0}
 
     # Get topics with active weekly subscribers
     print("→ Querying active weekly topics...")

--- a/backend/utils/process_weekly_reports.py
+++ b/backend/utils/process_weekly_reports.py
@@ -1,0 +1,318 @@
+"""
+Weekly topic report generation orchestration.
+
+CLI script to generate weekly reports for topics with active subscribers.
+Designed to run weekly (e.g., Monday morning) via cron or GitHub Actions.
+
+Usage:
+    # Generate reports for previous week (default)
+    uv run python -m utils.process_weekly_reports
+
+    # Generate for specific week
+    uv run python -m utils.process_weekly_reports --week-id 2026-W05
+
+    # Dry run (generate but don't store)
+    uv run python -m utils.process_weekly_reports --dry-run
+
+    # Force regenerate even if reports exist
+    uv run python -m utils.process_weekly_reports --force
+"""
+
+import argparse
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from models.weekly_report import WeeklyTopicReport
+from notifications.error_logger import log_notification_error
+from processing.weekly_report_generator import generate_weekly_topic_report
+from shared.db import get_supabase_client
+
+
+def get_iso_week_id(date: datetime | None = None) -> str:
+    """
+    Get ISO week ID in format YYYY-WXX.
+
+    Args:
+        date: Date to get week for (defaults to current date in Chicago timezone)
+
+    Returns:
+        Week ID string (e.g., "2026-W05")
+    """
+    if date is None:
+        date = datetime.now(ZoneInfo("America/Chicago"))
+    year, week, _ = date.isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+def get_previous_week_id() -> str:
+    """
+    Get ISO week ID for the previous week.
+
+    Returns:
+        Week ID string for last week (e.g., "2026-W04")
+    """
+    chicago_tz = ZoneInfo("America/Chicago")
+    last_week = datetime.now(chicago_tz) - timedelta(days=7)
+    return get_iso_week_id(last_week)
+
+
+def get_active_weekly_topics() -> list[str]:
+    """
+    Query notification_rules to find topics with active weekly subscribers.
+
+    Returns:
+        List of unique topic strings that have at least one active weekly rule
+    """
+    supabase = get_supabase_client()
+
+    try:
+        # Query notification rules for active weekly rules
+        response = (
+            supabase.table("notification_rules")
+            .select("topics")
+            .eq("is_active", True)
+            .eq("delivery_frequency", "weekly")
+            .execute()
+        )
+
+        # Extract and deduplicate topics
+        all_topics: set[str] = set()
+        for rule in response.data:
+            topics_list = rule.get("topics", [])  # type: ignore
+            if isinstance(topics_list, list):
+                all_topics.update(topics_list)
+
+        return sorted(list(all_topics))
+
+    except Exception as e:
+        print(f"⚠ Error querying active topics: {e}")
+        return []
+
+
+def report_exists(topic: str, week_id: str) -> bool:
+    """
+    Check if a report already exists for topic/week.
+
+    Args:
+        topic: Topic identifier
+        week_id: Week identifier (YYYY-WXX)
+
+    Returns:
+        True if report exists, False otherwise
+    """
+    supabase = get_supabase_client()
+
+    try:
+        response = (
+            supabase.table("weekly_topic_reports")
+            .select("id")
+            .eq("topic", topic)
+            .eq("week_id", week_id)
+            .limit(1)
+            .execute()
+        )
+
+        return len(response.data) > 0
+
+    except Exception:
+        return False
+
+
+def store_weekly_report(report: WeeklyTopicReport) -> bool:
+    """
+    Store generated report in weekly_topic_reports table.
+
+    Uses ON CONFLICT to handle duplicate week/topic (idempotent).
+
+    Args:
+        report: WeeklyTopicReport object to store
+
+    Returns:
+        True if stored successfully, False otherwise
+    """
+    supabase = get_supabase_client()
+
+    try:
+        # Convert Pydantic model to dict for insertion
+        report_data = {
+            "topic": report.topic,
+            "week_id": report.week_id,
+            "report_summary": report.report_summary,
+            "newsletter_ids": report.newsletter_ids,
+            "key_developments": (
+                [dev.model_dump() for dev in report.key_developments]
+                if report.key_developments
+                else None
+            ),
+        }
+
+        # Upsert (insert or update on conflict)
+        response = (
+            supabase.table("weekly_topic_reports")
+            .upsert(
+                report_data,
+                on_conflict="topic,week_id",  # Use unique constraint
+            )
+            .execute()
+        )
+
+        return len(response.data) > 0
+
+    except Exception as e:
+        print(f"  ✗ Failed to store report: {e}")
+        return False
+
+
+def process_weekly_reports(
+    week_id: str | None = None,
+    dry_run: bool = False,
+    force: bool = False,
+    model: str = "gpt-oss:20b",
+) -> dict[str, int]:
+    """
+    Main orchestration: Generate reports for all active topics.
+
+    Workflow:
+    1. Calculate week_id (defaults to previous week)
+    2. Query active weekly topics from notification_rules
+    3. For each topic:
+       a. Check if report already exists (skip if yes, unless force=True)
+       b. Generate report via generate_weekly_topic_report()
+       c. Store in database via store_weekly_report() (unless dry_run=True)
+    4. Return stats (generated, skipped, failed)
+
+    Args:
+        week_id: Week identifier (YYYY-WXX), defaults to previous week
+        dry_run: If True, generate but don't store
+        force: If True, regenerate even if report exists
+        model: Ollama model name
+
+    Returns:
+        Dictionary with stats: {generated, skipped, failed}
+    """
+    # Determine week to process
+    if week_id is None:
+        week_id = get_previous_week_id()
+
+    print(f"\n{'=' * 60}")
+    print(f"Weekly Report Generation - Week {week_id}")
+    print(f"{'=' * 60}")
+    print(f"Mode: {'DRY RUN' if dry_run else 'PRODUCTION'}")
+    print(f"Force: {'Yes' if force else 'No'}")
+    print(f"Model: {model}")
+    print()
+
+    # Get topics with active weekly subscribers
+    print("→ Querying active weekly topics...")
+    active_topics = get_active_weekly_topics()
+
+    if not active_topics:
+        print("ℹ No active weekly topics found (no users have weekly rules)")
+        return {"generated": 0, "skipped": 0, "failed": 0}
+
+    print(f"✓ Found {len(active_topics)} active topics:")
+    for topic in active_topics:
+        print(f"  - {topic}")
+    print()
+
+    # Process each topic
+    stats = {"generated": 0, "skipped": 0, "failed": 0}
+
+    for i, topic in enumerate(active_topics, 1):
+        print(f"[{i}/{len(active_topics)}] Processing: {topic}")
+
+        # Check if report already exists
+        if not force and report_exists(topic, week_id):
+            print(f"  ℹ Report already exists for {topic} / {week_id}, skipping")
+            stats["skipped"] += 1
+            print()
+            continue
+
+        # Generate report
+        try:
+            report = generate_weekly_topic_report(topic, week_id, model)
+
+            if report is None:
+                print("  ℹ No report generated (no newsletters or no content)")
+                stats["skipped"] += 1
+                print()
+                continue
+
+            # Store report (unless dry run)
+            if dry_run:
+                print("  ✓ Report generated (dry run - not storing)")
+                stats["generated"] += 1
+            else:
+                success = store_weekly_report(report)
+                if success:
+                    print("  ✓ Report stored successfully")
+                    stats["generated"] += 1
+                else:
+                    print("  ✗ Failed to store report")
+                    stats["failed"] += 1
+
+        except Exception as e:
+            print(f"  ✗ Error generating report: {e}")
+            error_file = log_notification_error(
+                error_type="weekly_report_generation",
+                error_message=str(e),
+                context={"week_id": week_id, "topic": topic},
+            )
+            print(f"  ⚠ Error logged to: {error_file}")
+            stats["failed"] += 1
+
+        print()
+
+    # Summary
+    print(f"{'=' * 60}")
+    print("Summary:")
+    print(f"  Generated: {stats['generated']}")
+    print(f"  Skipped:   {stats['skipped']}")
+    print(f"  Failed:    {stats['failed']}")
+    print(f"{'=' * 60}")
+
+    return stats
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Generate weekly topic reports for active subscribers"
+    )
+
+    parser.add_argument(
+        "--week-id",
+        type=str,
+        help="Week ID to process (YYYY-WXX format). Defaults to previous week.",
+    )
+
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Generate but don't store reports"
+    )
+
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Regenerate even if reports already exist for week",
+    )
+
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="gpt-oss:20b",
+        help="Ollama model to use (default: gpt-oss:20b)",
+    )
+
+    args = parser.parse_args()
+
+    stats = process_weekly_reports(
+        week_id=args.week_id, dry_run=args.dry_run, force=args.force, model=args.model
+    )
+
+    # Exit with non-zero if any failures
+    if stats["failed"] > 0:
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/utils/process_weekly_reports.py
+++ b/backend/utils/process_weekly_reports.py
@@ -173,13 +173,14 @@ def process_weekly_reports(
     week_id: str | None = None,
     dry_run: bool = False,
     force: bool = False,
+    current_week: bool = False,
     model: str = "gpt-oss:20b",
 ) -> dict[str, int]:
     """
     Main orchestration: Generate reports for all active topics.
 
     Workflow:
-    1. Calculate week_id (defaults to previous week)
+    1. Calculate week_id (defaults to previous week, or current week if --current-week)
     2. Query active weekly topics from notification_rules
     3. For each topic:
        a. Check if report already exists (skip if yes, unless force=True)
@@ -188,9 +189,10 @@ def process_weekly_reports(
     4. Return stats (generated, skipped, failed)
 
     Args:
-        week_id: Week identifier (YYYY-WXX), defaults to previous week
+        week_id: Week identifier (YYYY-WXX), defaults based on current_week flag
         dry_run: If True, generate but don't store
         force: If True, regenerate even if report exists
+        current_week: If True, use current week instead of previous week
         model: Ollama model name
 
     Returns:
@@ -198,7 +200,10 @@ def process_weekly_reports(
     """
     # Determine week to process
     if week_id is None:
-        week_id = get_previous_week_id()
+        if current_week:
+            week_id = get_iso_week_id()  # Current week
+        else:
+            week_id = get_previous_week_id()  # Previous week (default)
 
     print(f"\n{'=' * 60}")
     print(f"Weekly Report Generation - Week {week_id}")
@@ -309,6 +314,12 @@ def main() -> None:
     )
 
     parser.add_argument(
+        "--current-week",
+        action="store_true",
+        help="Use current week instead of previous week (useful for manual Sunday runs)",
+    )
+
+    parser.add_argument(
         "--model",
         type=str,
         default="gpt-oss:20b",
@@ -318,7 +329,11 @@ def main() -> None:
     args = parser.parse_args()
 
     stats = process_weekly_reports(
-        week_id=args.week_id, dry_run=args.dry_run, force=args.force, model=args.model
+        week_id=args.week_id,
+        dry_run=args.dry_run,
+        force=args.force,
+        current_week=args.current_week,
+        model=args.model,
     )
 
     # Exit with non-zero if any failures

--- a/backend/utils/test_weekly_summary.py
+++ b/backend/utils/test_weekly_summary.py
@@ -1,0 +1,245 @@
+"""
+Test and iterate on weekly summary generation.
+
+Allows you to quickly test the summary prompt against real or sample data
+without running the full weekly report pipeline.
+
+Usage:
+    # Test with an existing report from database
+    uv run python -m utils.test_weekly_summary --topic bike_lanes --week 2026-W04
+
+    # Test with sample data (no database query)
+    uv run python -m utils.test_weekly_summary --sample
+"""
+
+import argparse
+import os
+from dotenv import load_dotenv
+
+from models.types import NewsletterID
+from models.weekly_report import KeyDevelopment, WeeklySynthesis
+from processing.llm_processor import call_llm
+from prompts.weekly_synthesis import FACTUAL_SUMMARY
+from shared.db import get_supabase_client
+
+load_dotenv()
+
+ENABLE_LLM = os.getenv("ENABLE_LLM", "false").lower() == "true"
+
+
+def get_sample_facts() -> list[KeyDevelopment]:
+    """Get sample facts for testing without database access."""
+    return [
+        KeyDevelopment(
+            description="Concrete bike medians completed along Pratt Boulevard; remaining tasks include installing signage and modifying striping.",
+            wards=["40"],
+            newsletter_ids=[NewsletterID("98d9f7a0-8d3a-43ce-ac09-c31e4287bd6e")],
+        ),
+        KeyDevelopment(
+            description="CDOT temporarily closed the northern turning lane from Ainslie to Western heading south on Lincoln Avenue to install new traffic lights and adjust signal timing for improved bike lane alignment.",
+            wards=["40"],
+            newsletter_ids=[NewsletterID("98d9f7a0-8d3a-43ce-ac09-c31e4287bd6e")],
+        ),
+        KeyDevelopment(
+            description='The City of Chicago\'s Department of Finance announced a new reporting option for parking violations, adding "Vehicle Parked in Bike Lane" as a reportable offense. Residents can file these reports via 311, the CHI311 app, or the 311 website.',
+            wards=["43"],
+            newsletter_ids=[NewsletterID("f32c50a1-3402-4cfe-9f26-739d83942885")],
+        ),
+        KeyDevelopment(
+            description="The City of Chicago updated guidance and rules from CDOT on scooter and e-bike rides, providing new rules that may affect interactions with bike lanes.",
+            wards=["43"],
+            newsletter_ids=[NewsletterID("f32c50a1-3402-4cfe-9f26-739d83942885")],
+        ),
+        KeyDevelopment(
+            description="CDOT installed new bike racks on the 5600 block of North Kenmore, providing additional bike parking for residents and commuters in the 48th Ward.",
+            wards=["48"],
+            newsletter_ids=[NewsletterID("976ac29c-ac71-4b8b-8965-f7b80e4be47d")],
+        ),
+        KeyDevelopment(
+            description="CDOT launched the Bike Chicago program, offering 5,000 free bicycles with safety and maintenance equipment to age- and income-eligible Chicagoans.",
+            wards=["48"],
+            newsletter_ids=[NewsletterID("976ac29c-ac71-4b8b-8965-f7b80e4be47d")],
+        ),
+    ]
+
+
+def fetch_report_facts(
+    topic: str, week_id: str
+) -> tuple[list[KeyDevelopment], str] | None:
+    """
+    Fetch existing report facts from database.
+
+    Returns:
+        Tuple of (facts, topic_display_name) or None if not found
+    """
+    supabase = get_supabase_client()
+
+    try:
+        response = (
+            supabase.table("weekly_topic_reports")
+            .select("topic, key_developments")
+            .eq("topic", topic)
+            .eq("week_id", week_id)
+            .single()
+            .execute()
+        )
+
+        if not response.data:
+            print(f"✗ No report found for {topic} / {week_id}")
+            return None
+
+        data = response.data
+        raw_developments = data.get("key_developments", [])  # type: ignore
+
+        # Convert raw dicts to KeyDevelopment objects
+        facts = [KeyDevelopment(**dev) for dev in raw_developments]  # type: ignore
+
+        # Get friendly topic name
+        topic_names = {
+            "bike_lanes": "Bike Lanes and Cycling Infrastructure",
+            "4_flats_legalization": "4-Flats and Small-Scale Housing",
+            "missing_middle_housing": "Missing Middle Housing",
+            "accessory_dwelling_units": "Accessory Dwelling Units (ADUs)",
+            "single_stair_reform": "Single-Stair Building Reform",
+            "street_redesign": "Street Redesign and Reconstruction",
+            "street_safety_or_traffic_calming": "Street Safety and Traffic Calming",
+            "transit_funding": "Public Transit Funding and Service",
+            "city_budget": "City Budget and Fiscal Policy",
+            "tax_policy": "Tax Policy and Revenue",
+            "zoning_or_development_meeting_or_approval": "Zoning and Development Approvals",
+            "city_charter": "City Charter and Governance Reform",
+        }
+        topic_display = topic_names.get(topic, topic.replace("_", " ").title())
+
+        return (facts, topic_display)
+
+    except Exception as e:
+        print(f"✗ Error fetching report: {e}")
+        return None
+
+
+def synthesize_summary(
+    facts: list[KeyDevelopment],
+    topic_display: str,
+    week_id: str,
+    model: str = "gpt-oss:20b",
+) -> str:
+    """
+    Generate summary using the FACTUAL_SUMMARY prompt.
+
+    Args:
+        facts: List of KeyDevelopment objects
+        topic_display: Human-readable topic name
+        week_id: Week identifier (YYYY-WXX)
+        model: Ollama model name
+
+    Returns:
+        Generated summary text or error message
+    """
+    # Format facts for prompt
+    facts_text = []
+    for i, fact in enumerate(facts, 1):
+        ward_str = f"Wards {', '.join(fact.wards)}" if fact.wards else "Citywide"
+        facts_text.append(f"{i}. {fact.description} ({ward_str})")
+
+    facts_list = "\n".join(facts_text)
+
+    # Build prompt using FACTUAL_SUMMARY template
+    prompt = FACTUAL_SUMMARY.format(
+        topic_display=topic_display, week_id=week_id, facts_list=facts_list
+    )
+
+    # Call LLM
+    try:
+        print("\nGenerating summary...")
+        response = call_llm(model, prompt, WeeklySynthesis.model_json_schema())
+        data = WeeklySynthesis.model_validate_json(response)
+        return data.summary
+    except Exception as e:
+        return f"ERROR: {e}"
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Test weekly summary generation")
+
+    parser.add_argument(
+        "--topic",
+        type=str,
+        help="Topic to test (e.g., bike_lanes)",
+    )
+
+    parser.add_argument(
+        "--week",
+        type=str,
+        help="Week ID (YYYY-WXX format)",
+    )
+
+    parser.add_argument(
+        "--sample",
+        action="store_true",
+        help="Use sample data instead of fetching from database",
+    )
+
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="gpt-oss:20b",
+        help="Ollama model to use (default: gpt-oss:20b)",
+    )
+
+    args = parser.parse_args()
+
+    if not ENABLE_LLM:
+        print("✗ ENABLE_LLM is false. Set ENABLE_LLM=true in .env to test.")
+        exit(1)
+
+    # Get facts and topic display
+    if args.sample:
+        facts = get_sample_facts()
+        topic_display = "Bike Lanes and Cycling Infrastructure"
+        week_id = "2026-W04"
+        print("Using sample data for testing...")
+    else:
+        if not args.topic or not args.week:
+            print("✗ Error: --topic and --week required unless using --sample")
+            parser.print_help()
+            exit(1)
+
+        result = fetch_report_facts(args.topic, args.week)
+        if not result:
+            exit(1)
+
+        facts, topic_display = result
+        week_id = args.week
+        print(f"✓ Loaded {len(facts)} facts from database")
+
+    print(f"\nTopic: {topic_display}")
+    print(f"Week: {week_id}")
+    print(f"Facts: {len(facts)}")
+    print()
+
+    # Print facts for reference
+    print("FACTS BEING SYNTHESIZED:")
+    print("-" * 80)
+    for i, fact in enumerate(facts, 1):
+        ward_str = f"Wards {', '.join(fact.wards)}" if fact.wards else "Citywide"
+        print(f"{i}. {fact.description} ({ward_str})")
+    print()
+
+    # Generate summary
+    summary = synthesize_summary(facts, topic_display, week_id, args.model)
+
+    # Display result
+    print("\n" + "=" * 80)
+    print("GENERATED SUMMARY:")
+    print("-" * 80)
+    print(summary)
+    print()
+    print(f"Character count: {len(summary)}")
+    print(f"Word count: {len(summary.split())}")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/utils/time_tests.py
+++ b/backend/utils/time_tests.py
@@ -1,0 +1,79 @@
+"""
+Performance Profiling Utility for Backend Tests
+
+This script discovers and runs all backend tests while timing individual test
+execution. It outputs the top 20 slowest tests to help identify performance
+bottlenecks in the test suite.
+
+Usage:
+    uv run python utils/time_tests.py
+"""
+
+import unittest
+import time
+import sys
+from pathlib import Path
+from typing import Any
+
+# Add the backend directory to sys.path to resolve local imports correctly
+backend_root = Path(__file__).parent.parent.absolute()
+if str(backend_root) not in sys.path:
+    sys.path.insert(0, str(backend_root))
+
+
+class TimingResult(unittest.TextTestResult):
+    """Custom TestResult that records the duration of each test."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.recorded_durations: list[tuple[str, float]] = []
+        self._start_time: float = 0.0
+
+    def startTest(self, test: unittest.TestCase) -> None:
+        self._start_time = time.time()
+        super().startTest(test)
+
+    def stopTest(self, test: unittest.TestCase) -> None:
+        duration = time.time() - self._start_time
+        self.recorded_durations.append((str(test), duration))
+        super().stopTest(test)
+
+
+class TimingRunner(unittest.TextTestRunner):
+    """Custom TestRunner that uses TimingResult and prints slow tests."""
+
+    def _makeResult(self) -> TimingResult:
+        # Override _makeResult to return our custom TimingResult
+        return TimingResult(self.stream, self.descriptions, self.verbosity)
+
+    def run(self, test: unittest.TestSuite | unittest.TestCase) -> Any:
+        # We call super().run which returns a TestResult
+        result = super().run(test)
+
+        # Ensure result is our TimingResult before accessing durations
+        if isinstance(result, TimingResult):
+            # Sort by duration descending and display top 20
+            self.stream.writeln("\nTop 20 Slowest Tests:")
+            self.stream.writeln("=" * 60)
+            sorted_durations = sorted(
+                result.recorded_durations, key=lambda x: x[1], reverse=True
+            )
+            for name, duration in sorted_durations[:20]:
+                self.stream.writeln(f"{duration:7.3f}s : {name}")
+            self.stream.writeln("=" * 60)
+
+        return result
+
+
+if __name__ == "__main__":
+    # Ensure we are running from the backend directory
+    os_cwd = Path.cwd()
+    if (os_cwd / "tests").exists():
+        loader = unittest.TestLoader()
+        suite = loader.discover("tests")
+        runner = TimingRunner(verbosity=1)
+        runner.run(suite)
+    else:
+        print(f"Error: Could not find 'tests' directory in {os_cwd}")
+        print("Please run this script from the 'backend' root directory.")
+        sys.exit(1)

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -66,4 +66,5 @@ export interface NotificationRule {
   min_relevance_score?: number;
   source_ids?: number[];
   ward_numbers?: string[]; // TEXT[] to match sources.ward_number TEXT type
+  delivery_frequency: "daily" | "weekly";
 }

--- a/frontend/src/pages/api/notifications/create-rule.ts
+++ b/frontend/src/pages/api/notifications/create-rule.ts
@@ -15,38 +15,49 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
 
   const formData = await request.formData();
   const name = formData.get("name")?.toString();
-  const ruleType = formData.get("rule_type")?.toString() || "search";
-  let topics = formData.getAll("topics").map((t) => t.toString());
+  const topics = formData.getAll("topics").map((t) => t.toString());
   let searchTerm = formData.get("search_term")?.toString().trim();
-  const wards = formData
+  let wards = formData
     .getAll("wards")
     .map((w) => w.toString().trim())
     .filter((w) => w.length > 0);
   const isActive = formData.get("is_active") === "on";
-  let deliveryFrequency = formData.get("delivery_frequency")?.toString() || "daily";
 
   if (!name) {
     return redirect("/preferences?error=Rule name is required");
   }
 
-  // Handle Mutual Exclusivity based on rule type
-  if (ruleType === "search") {
-    // Search Mode: Clear topics, require search term, FORCE daily frequency
-    topics = [];
-    deliveryFrequency = "daily";
-    if (!searchTerm) {
-      return redirect("/preferences?error=Search phrase is required");
+  // Validation: Weekly rules cannot have ward filters
+  if (deliveryFrequency === "weekly" && wards.length > 0) {
+    return redirect(
+      "/preferences?error=Ward filters cannot be applied to weekly summaries. Weekly summaries cover citywide activity.",
+    );
+  }
+
+  // Validation: Weekly rules must have topics
+  if (deliveryFrequency === "weekly") {
+    if (topics.length === 0) {
+      return redirect(
+        "/preferences?error=At least one topic is required for weekly summaries",
+      );
     }
-    if (searchTerm.length > 100) {
+    // Weekly rules cannot have search terms
+    searchTerm = undefined;
+    // Clear any ward filters (belt-and-suspenders)
+    wards = [];
+  }
+
+  // Validation: Daily rules must have at least search term or topics
+  if (deliveryFrequency === "daily") {
+    if (!searchTerm && topics.length === 0) {
+      return redirect(
+        "/preferences?error=Please specify at least one topic or search phrase",
+      );
+    }
+    if (searchTerm && searchTerm.length > 100) {
       return redirect(
         "/preferences?error=Search phrase must be under 100 characters",
       );
-    }
-  } else {
-    // Topic Mode: Clear search term, require topics
-    searchTerm = undefined;
-    if (topics.length === 0) {
-      return redirect("/preferences?error=At least one topic is required");
     }
   }
 

--- a/frontend/src/pages/api/notifications/create-rule.ts
+++ b/frontend/src/pages/api/notifications/create-rule.ts
@@ -23,6 +23,7 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
     .map((w) => w.toString().trim())
     .filter((w) => w.length > 0);
   const isActive = formData.get("is_active") === "on";
+  let deliveryFrequency = formData.get("delivery_frequency")?.toString() || "daily";
 
   if (!name) {
     return redirect("/preferences?error=Rule name is required");
@@ -30,8 +31,9 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
 
   // Handle Mutual Exclusivity based on rule type
   if (ruleType === "search") {
-    // Search Mode: Clear topics, require search term
+    // Search Mode: Clear topics, require search term, FORCE daily frequency
     topics = [];
+    deliveryFrequency = "daily";
     if (!searchTerm) {
       return redirect("/preferences?error=Search phrase is required");
     }
@@ -72,6 +74,7 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
     search_term: searchTerm || null,
     ward_numbers: wards.length > 0 ? wards : null,
     is_active: isActive,
+    delivery_frequency: deliveryFrequency,
   });
 
   if (error) {

--- a/frontend/src/pages/api/notifications/create-rule.ts
+++ b/frontend/src/pages/api/notifications/create-rule.ts
@@ -22,33 +22,32 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
     .map((w) => w.toString().trim())
     .filter((w) => w.length > 0);
   const isActive = formData.get("is_active") === "on";
+  let deliveryFrequency =
+    formData.get("delivery_frequency")?.toString() || "daily";
 
   if (!name) {
     return redirect("/preferences?error=Rule name is required");
   }
 
-  // Validation: Weekly rules cannot have ward filters
-  if (deliveryFrequency === "weekly" && wards.length > 0) {
-    return redirect(
-      "/preferences?error=Ward filters cannot be applied to weekly summaries. Weekly summaries cover citywide activity.",
-    );
-  }
-
-  // Validation: Weekly rules must have topics
+  // Validation: Weekly rules
   if (deliveryFrequency === "weekly") {
     if (topics.length === 0) {
       return redirect(
         "/preferences?error=At least one topic is required for weekly summaries",
       );
     }
-    // Weekly rules cannot have search terms
+    if (wards.length > 0) {
+      return redirect(
+        "/preferences?error=Ward filters cannot be applied to weekly summaries. Weekly summaries cover citywide activity.",
+      );
+    }
+    // Weekly rules cannot have search terms or ward filters
     searchTerm = undefined;
-    // Clear any ward filters (belt-and-suspenders)
     wards = [];
-  }
+  } else {
+    // Validation: Daily rules (default)
+    deliveryFrequency = "daily"; // Ensure it's exactly 'daily' if not 'weekly'
 
-  // Validation: Daily rules must have at least search term or topics
-  if (deliveryFrequency === "daily") {
     if (!searchTerm && topics.length === 0) {
       return redirect(
         "/preferences?error=Please specify at least one topic or search phrase",

--- a/frontend/src/pages/api/notifications/update-rule.ts
+++ b/frontend/src/pages/api/notifications/update-rule.ts
@@ -30,28 +30,23 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
     return redirect("/preferences?error=Rule ID and name are required");
   }
 
-  // Validation: Weekly rules cannot have ward filters
-  if (deliveryFrequency === "weekly" && wards.length > 0) {
-    return redirect(
-      "/preferences?error=Ward filters cannot be applied to weekly summaries. Weekly summaries cover citywide activity.",
-    );
-  }
-
-  // Validation: Weekly rules must have topics
+  // Validation: Weekly rules
   if (deliveryFrequency === "weekly") {
     if (topics.length === 0) {
       return redirect(
         "/preferences?error=At least one topic is required for weekly summaries",
       );
     }
-    // Weekly rules cannot have search terms
+    if (wards.length > 0) {
+      return redirect(
+        "/preferences?error=Ward filters cannot be applied to weekly summaries. Weekly summaries cover citywide activity.",
+      );
+    }
+    // Weekly rules cannot have search terms or ward filters
     searchTerm = undefined;
-    // Clear any ward filters (belt-and-suspenders)
     wards = [];
-  }
-
-  // Validation: Daily rules must have at least search term or topics
-  if (deliveryFrequency === "daily") {
+  } else {
+    // Validation: Daily rules (default)
     if (!searchTerm && topics.length === 0) {
       return redirect(
         "/preferences?error=Please specify at least one topic or search phrase",

--- a/frontend/src/pages/api/notifications/update-rule.ts
+++ b/frontend/src/pages/api/notifications/update-rule.ts
@@ -16,38 +16,51 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
   const formData = await request.formData();
   const ruleId = formData.get("rule_id")?.toString();
   const name = formData.get("name")?.toString();
-  const ruleType = formData.get("rule_type")?.toString() || "search";
-  let topics = formData.getAll("topics").map((t) => t.toString());
+  const deliveryFrequency =
+    formData.get("delivery_frequency")?.toString() || "daily";
+  const topics = formData.getAll("topics").map((t) => t.toString());
   let searchTerm = formData.get("search_term")?.toString().trim();
-  const wards = formData
+  let wards = formData
     .getAll("wards")
     .map((w) => w.toString().trim())
     .filter((w) => w.length > 0);
   const isActive = formData.get("is_active") === "on";
-  let deliveryFrequency = formData.get("delivery_frequency")?.toString() || "daily";
 
   if (!ruleId || !name) {
     return redirect("/preferences?error=Rule ID and name are required");
   }
 
-  // Handle Mutual Exclusivity based on rule type
-  if (ruleType === "search") {
-    // Search Mode: Clear topics, require search term, FORCE daily frequency
-    topics = [];
-    deliveryFrequency = "daily";
-    if (!searchTerm) {
-      return redirect("/preferences?error=Search phrase is required");
+  // Validation: Weekly rules cannot have ward filters
+  if (deliveryFrequency === "weekly" && wards.length > 0) {
+    return redirect(
+      "/preferences?error=Ward filters cannot be applied to weekly summaries. Weekly summaries cover citywide activity.",
+    );
+  }
+
+  // Validation: Weekly rules must have topics
+  if (deliveryFrequency === "weekly") {
+    if (topics.length === 0) {
+      return redirect(
+        "/preferences?error=At least one topic is required for weekly summaries",
+      );
     }
-    if (searchTerm.length > 100) {
+    // Weekly rules cannot have search terms
+    searchTerm = undefined;
+    // Clear any ward filters (belt-and-suspenders)
+    wards = [];
+  }
+
+  // Validation: Daily rules must have at least search term or topics
+  if (deliveryFrequency === "daily") {
+    if (!searchTerm && topics.length === 0) {
+      return redirect(
+        "/preferences?error=Please specify at least one topic or search phrase",
+      );
+    }
+    if (searchTerm && searchTerm.length > 100) {
       return redirect(
         "/preferences?error=Search phrase must be under 100 characters",
       );
-    }
-  } else {
-    // Topic Mode: Clear search term, require topics
-    searchTerm = undefined;
-    if (topics.length === 0) {
-      return redirect("/preferences?error=At least one topic is required");
     }
   }
 

--- a/frontend/src/pages/api/notifications/update-rule.ts
+++ b/frontend/src/pages/api/notifications/update-rule.ts
@@ -24,6 +24,7 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
     .map((w) => w.toString().trim())
     .filter((w) => w.length > 0);
   const isActive = formData.get("is_active") === "on";
+  let deliveryFrequency = formData.get("delivery_frequency")?.toString() || "daily";
 
   if (!ruleId || !name) {
     return redirect("/preferences?error=Rule ID and name are required");
@@ -31,8 +32,9 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
 
   // Handle Mutual Exclusivity based on rule type
   if (ruleType === "search") {
-    // Search Mode: Clear topics, require search term
+    // Search Mode: Clear topics, require search term, FORCE daily frequency
     topics = [];
+    deliveryFrequency = "daily";
     if (!searchTerm) {
       return redirect("/preferences?error=Search phrase is required");
     }
@@ -58,6 +60,7 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
       search_term: searchTerm || null,
       ward_numbers: wards.length > 0 ? wards : null,
       is_active: isActive,
+      delivery_frequency: deliveryFrequency,
     })
     .eq("id", ruleId)
     .eq("user_id", user.id);

--- a/frontend/src/pages/preferences.astro
+++ b/frontend/src/pages/preferences.astro
@@ -322,10 +322,10 @@ const message = Astro.url.searchParams.get('message');
                     data-rule-delivery-frequency={rule.delivery_frequency || 'daily'}
                     data-rule-active={rule.is_active}
                   >
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="w-4 h-4 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
                     </svg>
-                    Edit
+                    <span class="pointer-events-none">Edit</span>
                   </button>
                   <form action="/api/notifications/delete-rule" method="POST" enctype="application/x-www-form-urlencoded" class="inline">
                     <input type="hidden" name="rule_id" value={rule.id} />
@@ -637,7 +637,7 @@ const message = Astro.url.searchParams.get('message');
     // Open modal for editing rule
     editRuleBtns.forEach(btn => {
       btn.addEventListener('click', (e) => {
-        const target = e.target as HTMLButtonElement;
+        const target = e.currentTarget as HTMLButtonElement;
         const ruleId = target.dataset.ruleId;
         const ruleName = target.dataset.ruleName;
         const ruleTopics = JSON.parse(target.dataset.ruleTopics || '[]');

--- a/frontend/src/pages/preferences.astro
+++ b/frontend/src/pages/preferences.astro
@@ -169,7 +169,7 @@ const message = Astro.url.searchParams.get('message');
                 Enable Email Notifications
               </label>
               <p class="text-sm text-gray-600">
-                Receive daily digest emails when newsletters match your rules
+                Receive digest emails when newsletters match your rules
               </p>
             </div>
             <label class="relative inline-flex items-center cursor-pointer flex-shrink-0">
@@ -275,6 +275,11 @@ const message = Astro.url.searchParams.get('message');
                         Disabled
                       </span>
                     )}
+                    {rule.delivery_frequency === 'weekly' && (
+                      <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold bg-purple-100 text-purple-800 border border-purple-200">
+                        Weekly Report
+                      </span>
+                    )}
                   </div>
                   {rule.topics && rule.topics.length > 0 && (
                     <div class="flex flex-wrap gap-2">
@@ -314,6 +319,7 @@ const message = Astro.url.searchParams.get('message');
                     data-rule-topics={JSON.stringify(rule.topics)}
                     data-rule-ward-numbers={JSON.stringify(rule.ward_numbers || [])}
                     data-rule-search-term={rule.search_term || ''}
+                    data-rule-delivery-frequency={rule.delivery_frequency || 'daily'}
                     data-rule-active={rule.is_active}
                   >
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -401,6 +407,39 @@ const message = Astro.url.searchParams.get('message');
             <label class="block text-sm font-semibold text-gray-900 mb-3">
               Topics (select at least one)
             </label>
+            
+            <!-- Frequency Selection (Only for Topics) -->
+            <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
+              <label class="block text-sm font-semibold text-gray-900 mb-2">Delivery Frequency</label>
+              <div class="flex flex-col space-y-2">
+                <label class="inline-flex items-start">
+                  <input
+                    type="radio"
+                    name="delivery_frequency"
+                    value="daily"
+                    checked
+                    class="mt-1 form-radio h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
+                  />
+                  <div class="ml-2">
+                    <span class="block text-sm font-medium text-gray-900">Daily Digest</span>
+                    <span class="block text-xs text-gray-600">Get emails whenever a newsletter matches your topics.</span>
+                  </div>
+                </label>
+                <label class="inline-flex items-start">
+                  <input
+                    type="radio"
+                    name="delivery_frequency"
+                    value="weekly"
+                    class="mt-1 form-radio h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
+                  />
+                  <div class="ml-2">
+                    <span class="block text-sm font-medium text-gray-900">Weekly Summary</span>
+                    <span class="block text-xs text-gray-600">Get a single weekly report summarizing all activity for your topics.</span>
+                  </div>
+                </label>
+              </div>
+            </div>
+
             <div class="space-y-4 max-h-96 overflow-y-auto border border-gray-200 rounded-lg p-4 bg-gray-50">
               {Object.entries(TOPIC_CATEGORIES).map(([category, topics]) => (
                 <div class="bg-white rounded-lg p-4 border border-gray-200">
@@ -535,6 +574,7 @@ const message = Astro.url.searchParams.get('message');
     const ruleNameInput = document.getElementById('ruleName') as HTMLInputElement;
     const searchTermInput = document.getElementById('searchTerm') as HTMLInputElement;
     const isActiveInput = document.getElementById('isActive') as HTMLInputElement;
+    const frequencyRadios = document.querySelectorAll('input[name="delivery_frequency"]') as NodeListOf<HTMLInputElement>;
     const topicSection = document.getElementById('topicSection');
     const searchSection = document.getElementById('searchSection');
     const ruleTypeRadios = document.querySelectorAll('input[name="rule_type"]') as NodeListOf<HTMLInputElement>;
@@ -582,6 +622,8 @@ const message = Astro.url.searchParams.get('message');
         searchTermInput.value = '';
         // Reset to default (search)
         ruleTypeRadios[0].checked = true;
+        // Reset frequency to daily
+        if (frequencyRadios.length > 0) frequencyRadios[0].checked = true;
         
         // Reset wards UI
         wardSelectionContainer?.classList.add('hidden');
@@ -601,6 +643,7 @@ const message = Astro.url.searchParams.get('message');
         const ruleTopics = JSON.parse(target.dataset.ruleTopics || '[]');
         const ruleWards = JSON.parse(target.dataset.ruleWardNumbers || '[]');
         const ruleSearchTerm = target.dataset.ruleSearchTerm;
+        const ruleFrequency = target.dataset.ruleDeliveryFrequency || 'daily';
         const ruleActive = target.dataset.ruleActive === 'true';
 
         modalTitle!.textContent = 'Edit Notification Rule';
@@ -609,6 +652,11 @@ const message = Astro.url.searchParams.get('message');
         ruleNameInput.value = ruleName || '';
         searchTermInput.value = ruleSearchTerm || '';
         isActiveInput.checked = ruleActive;
+
+        // Set frequency
+        frequencyRadios.forEach(radio => {
+          if (radio.value === ruleFrequency) radio.checked = true;
+        });
 
         // Set correct rule type
         if (ruleSearchTerm) {

--- a/frontend/src/pages/preferences.astro
+++ b/frontend/src/pages/preferences.astro
@@ -377,121 +377,184 @@ const message = Astro.url.searchParams.get('message');
             />
           </div>
 
-          <!-- Rule Type Selection -->
+          <!-- Notification Type Selection -->
           <div>
-            <label class="block text-sm font-semibold text-gray-900 mb-2">Match By</label>
-            <div class="flex items-center space-x-4">
-              <label class="inline-flex items-center">
-                <input
-                  type="radio"
-                  name="rule_type"
-                  value="search"
-                  checked
-                  class="form-radio h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
-                />
-                <span class="ml-2 text-gray-700">Search Phrase</span>
-              </label>
-              <label class="inline-flex items-center">
-                <input
-                  type="radio"
-                  name="rule_type"
-                  value="topic"
-                  class="form-radio h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
-                />
-                <span class="ml-2 text-gray-700">Topics (Beta)</span>
-              </label>
-            </div>
-          </div>
-
-          <div id="topicSection" class="hidden">
             <label class="block text-sm font-semibold text-gray-900 mb-3">
-              Topics (select at least one)
+              Notification Type
             </label>
-            
-            <!-- Frequency Selection (Only for Topics) -->
-            <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
-              <label class="block text-sm font-semibold text-gray-900 mb-2">Delivery Frequency</label>
-              <div class="flex flex-col space-y-2">
-                <label class="inline-flex items-start">
-                  <input
-                    type="radio"
-                    name="delivery_frequency"
-                    value="daily"
-                    checked
-                    class="mt-1 form-radio h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
-                  />
-                  <div class="ml-2">
-                    <span class="block text-sm font-medium text-gray-900">Daily Digest</span>
-                    <span class="block text-xs text-gray-600">Get emails whenever a newsletter matches your topics.</span>
-                  </div>
-                </label>
-                <label class="inline-flex items-start">
-                  <input
-                    type="radio"
-                    name="delivery_frequency"
-                    value="weekly"
-                    class="mt-1 form-radio h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
-                  />
-                  <div class="ml-2">
-                    <span class="block text-sm font-medium text-gray-900">Weekly Summary</span>
-                    <span class="block text-xs text-gray-600">Get a single weekly report summarizing all activity for your topics.</span>
-                  </div>
-                </label>
-              </div>
-            </div>
-
-            <div class="space-y-4 max-h-96 overflow-y-auto border border-gray-200 rounded-lg p-4 bg-gray-50">
-              {Object.entries(TOPIC_CATEGORIES).map(([category, topics]) => (
-                <div class="bg-white rounded-lg p-4 border border-gray-200">
-                  <p class="font-bold text-sm text-gray-900 mb-3 flex items-center gap-2">
-                    <svg class="w-4 h-4 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
-                      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3.293 1.293a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 01-1.414-1.414L7.586 10 5.293 7.707a1 1 0 010-1.414zM11 12a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
-                    </svg>
-                    {category}
-                  </p>
-                  <div class="space-y-2 ml-1">
-                    {topics.map((topic) => (
-                      <label class="flex items-center hover:bg-blue-50 p-2 rounded-md cursor-pointer transition-colors">
-                        <input
-                          type="checkbox"
-                          name="topics"
-                          value={topic}
-                          class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                        />
-                        <span class="ml-3 text-sm text-gray-700 font-medium">{formatTopic(topic)}</span>
-                      </label>
-                    ))}
-                  </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <!-- Daily Digest Card -->
+              <label class="relative flex flex-col p-4 border-2 border-gray-200 rounded-lg cursor-pointer transition-all hover:bg-blue-50 hover:border-blue-300 has-[:checked]:border-blue-600 has-[:checked]:bg-blue-50">
+                <input
+                  type="radio"
+                  name="notification_type"
+                  value="daily"
+                  checked
+                  class="sr-only peer"
+                />
+                <div class="flex items-center gap-2 mb-2">
+                  <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/>
+                  </svg>
+                  <span class="text-base font-semibold text-gray-900">Daily Digest</span>
                 </div>
-              ))}
+                <p class="text-sm text-gray-600 mb-2">
+                  Get notified when newsletters match your interests
+                </p>
+                <ul class="text-xs text-gray-500 space-y-1">
+                  <li>✓ Filter by topics, keywords, or wards</li>
+                  <li>✓ Receive emails as newsletters arrive</li>
+                </ul>
+              </label>
+
+              <!-- Weekly Summary Card -->
+              <label class="relative flex flex-col p-4 border-2 border-gray-200 rounded-lg cursor-pointer transition-all hover:bg-purple-50 hover:border-purple-300 has-[:checked]:border-purple-600 has-[:checked]:bg-purple-50">
+                <input
+                  type="radio"
+                  name="notification_type"
+                  value="weekly"
+                  class="sr-only peer"
+                />
+                <div class="flex items-center gap-2 mb-2">
+                  <svg class="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                  </svg>
+                  <span class="text-base font-semibold text-gray-900">Weekly Summary</span>
+                </div>
+                <p class="text-sm text-gray-600 mb-2">
+                  Get weekly topic reports with citywide activity
+                </p>
+                <ul class="text-xs text-gray-500 space-y-1">
+                  <li>✓ Select topics to track</li>
+                  <li>✓ Receive summaries every Monday</li>
+                </ul>
+              </label>
             </div>
           </div>
 
-          <div id="searchSection">
-            <label for="searchTerm" class="block text-sm font-semibold text-gray-900 mb-2">
-              Search Phrase
-            </label>
-            <div class="relative">
-              <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
-                </svg>
+          <!-- Daily Options Section -->
+          <div id="dailyOptionsSection">
+            <div>
+              <label class="block text-sm font-semibold text-gray-900 mb-3">
+                Match newsletters by (choose one or both)
+              </label>
+
+              <!-- Search Term Input -->
+              <div class="mb-4">
+                <label for="searchTerm" class="block text-sm font-medium text-gray-700 mb-2">
+                  Search Phrase (optional)
+                </label>
+                <div class="relative">
+                  <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                    </svg>
+                  </div>
+                  <input
+                    type="text"
+                    id="searchTerm"
+                    name="search_term"
+                    placeholder="e.g., CTA, housing, zoning"
+                    maxlength="100"
+                    class="w-full pl-10 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-base"
+                  />
+                </div>
+                <p class="text-xs text-gray-500 mt-1">
+                  Notify if newsletter contains this exact phrase (case-insensitive)
+                </p>
               </div>
-              <input
-                type="text"
-                id="searchTerm"
-                name="search_term"
-                placeholder="e.g., CTA"
-                maxlength="100"
-                class="w-full pl-10 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-base"
-              />
+
+              <!-- Topics (optional for daily) -->
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-3">
+                  Topics (optional)
+                </label>
+                <div class="space-y-4 max-h-96 overflow-y-auto border border-gray-200 rounded-lg p-4 bg-gray-50">
+                  {Object.entries(TOPIC_CATEGORIES).map(([category, topics]) => (
+                    <div class="bg-white rounded-lg p-4 border border-gray-200">
+                      <p class="font-bold text-sm text-gray-900 mb-3 flex items-center gap-2">
+                        <svg class="w-4 h-4 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
+                          <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3.293 1.293a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 01-1.414-1.414L7.586 10 5.293 7.707a1 1 0 010-1.414zM11 12a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
+                        </svg>
+                        {category}
+                      </p>
+                      <div class="space-y-2 ml-1">
+                        {topics.map((topic) => (
+                          <label class="flex items-center hover:bg-blue-50 p-2 rounded-md cursor-pointer transition-colors">
+                            <input
+                              type="checkbox"
+                              name="topics"
+                              value={topic}
+                              class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                            />
+                            <span class="ml-3 text-sm text-gray-700 font-medium">{formatTopic(topic)}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
-            <p class="text-xs text-gray-500 mt-1">
-              Notify if the newsletter contains this exact phrase
-            </p>
           </div>
 
-          <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+          <!-- Weekly Options Section -->
+          <div id="weeklyOptionsSection" class="hidden">
+            <div>
+              <label class="block text-sm font-semibold text-gray-900 mb-3">
+                Select Topics (at least one required)
+              </label>
+              <div class="space-y-4 max-h-96 overflow-y-auto border border-gray-200 rounded-lg p-4 bg-gray-50">
+                {Object.entries(TOPIC_CATEGORIES).map(([category, topics]) => (
+                  <div class="bg-white rounded-lg p-4 border border-gray-200">
+                    <p class="font-bold text-sm text-gray-900 mb-3 flex items-center gap-2">
+                      <svg class="w-4 h-4 text-purple-600" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3.293 1.293a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 01-1.414-1.414L7.586 10 5.293 7.707a1 1 0 010-1.414zM11 12a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
+                      </svg>
+                      {category}
+                    </p>
+                    <div class="space-y-2 ml-1">
+                      {topics.map((topic) => (
+                        <label class="flex items-center hover:bg-purple-50 p-2 rounded-md cursor-pointer transition-colors">
+                          <input
+                            type="checkbox"
+                            name="topics"
+                            value={topic}
+                            class="h-4 w-4 text-purple-600 focus:ring-purple-500 border-gray-300 rounded"
+                          />
+                          <span class="ml-3 text-sm text-gray-700 font-medium">{formatTopic(topic)}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <!-- Informational callout -->
+            <div class="mt-4 bg-purple-50 border border-purple-200 rounded-lg p-4">
+              <div class="flex items-start gap-3">
+                <svg class="w-5 h-5 text-purple-600 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+                  <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+                </svg>
+                <div>
+                  <p class="text-sm font-semibold text-purple-900 mb-1">
+                    About Weekly Summaries
+                  </p>
+                  <p class="text-sm text-purple-800">
+                    Weekly summaries provide citywide overviews of activity for your selected topics.
+                    They include newsletters from all wards and are delivered every Monday morning.
+                  </p>
+                  <p class="text-xs text-purple-700 mt-2">
+                    💡 Want ward-specific updates? Use Daily Digest with a ward filter instead.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Ward Filter (Daily Only) -->
+          <div id="wardFilterSection" class="bg-gray-50 border border-gray-200 rounded-lg p-4">
             <div class="flex items-center justify-between mb-2">
               <label class="block text-sm font-semibold text-gray-900">
                 Filter by Ward (Optional)
@@ -504,10 +567,10 @@ const message = Astro.url.searchParams.get('message');
                 Show Wards
               </button>
             </div>
-            
+
             <div id="wardSelectionContainer" class="hidden mt-3">
               <p class="text-xs text-gray-500 mb-3">
-                Only notify if the newsletter comes from a specific Ward. If none selected, all Wards are included.
+                Only receive notifications for newsletters from specific wards. If none selected, all wards are included.
               </p>
               <div class="grid grid-cols-5 sm:grid-cols-8 gap-2">
                 {availableWards.map((ward) => (
@@ -574,10 +637,10 @@ const message = Astro.url.searchParams.get('message');
     const ruleNameInput = document.getElementById('ruleName') as HTMLInputElement;
     const searchTermInput = document.getElementById('searchTerm') as HTMLInputElement;
     const isActiveInput = document.getElementById('isActive') as HTMLInputElement;
-    const frequencyRadios = document.querySelectorAll('input[name="delivery_frequency"]') as NodeListOf<HTMLInputElement>;
-    const topicSection = document.getElementById('topicSection');
-    const searchSection = document.getElementById('searchSection');
-    const ruleTypeRadios = document.querySelectorAll('input[name="rule_type"]') as NodeListOf<HTMLInputElement>;
+    const notificationTypeRadios = document.querySelectorAll('input[name="notification_type"]') as NodeListOf<HTMLInputElement>;
+    const dailyOptionsSection = document.getElementById('dailyOptionsSection');
+    const weeklyOptionsSection = document.getElementById('weeklyOptionsSection');
+    const wardFilterSection = document.getElementById('wardFilterSection');
     const cancelBtn = document.getElementById('cancelBtn');
     const addRuleBtns = document.querySelectorAll('#addRuleBtn, #addRuleBtn2');
     const editRuleBtns = document.querySelectorAll('.edit-rule-btn');
@@ -596,21 +659,87 @@ const message = Astro.url.searchParams.get('message');
       }
     });
 
-    // Toggle sections based on rule type
-    function toggleSections() {
-      const selectedType = document.querySelector('input[name="rule_type"]:checked') as HTMLInputElement;
-      if (selectedType.value === 'topic') {
-        topicSection?.classList.remove('hidden');
-        searchSection?.classList.add('hidden');
+    // Toggle sections based on notification type
+    function toggleNotificationTypeSections() {
+      const selectedType = document.querySelector('input[name="notification_type"]:checked') as HTMLInputElement;
+      const wardCheckboxes = document.querySelectorAll('input[name="wards"]') as NodeListOf<HTMLInputElement>;
+
+      // Get topic checkboxes from both sections
+      const dailyTopicCheckboxes = dailyOptionsSection?.querySelectorAll('input[name="topics"]') as NodeListOf<HTMLInputElement>;
+      const weeklyTopicCheckboxes = weeklyOptionsSection?.querySelectorAll('input[name="topics"]') as NodeListOf<HTMLInputElement>;
+
+      if (selectedType && selectedType.value === 'weekly') {
+        // Switching to weekly: sync topics from daily to weekly, then clear daily
+        const checkedTopics = Array.from(dailyTopicCheckboxes || [])
+          .filter(cb => cb.checked)
+          .map(cb => cb.value);
+
+        // Check corresponding topics in weekly section
+        weeklyTopicCheckboxes?.forEach(cb => {
+          cb.checked = checkedTopics.includes(cb.value);
+        });
+
+        // Uncheck all topics in daily section (prevent duplication)
+        dailyTopicCheckboxes?.forEach(cb => cb.checked = false);
+
+        // Show weekly options, hide daily options and ward filter
+        dailyOptionsSection?.classList.add('hidden');
+        weeklyOptionsSection?.classList.remove('hidden');
+        wardFilterSection?.classList.add('hidden');
+
+        // Clear ward selections
+        wardCheckboxes.forEach(cb => cb.checked = false);
+        wardSelectionContainer?.classList.add('hidden');
+        if (toggleWardsBtn) toggleWardsBtn.textContent = 'Show Wards';
+
+        // Set delivery_frequency hidden input to weekly
+        let frequencyInput = document.getElementById('hidden_frequency') as HTMLInputElement;
+        if (!frequencyInput) {
+          frequencyInput = document.createElement('input');
+          frequencyInput.type = 'hidden';
+          frequencyInput.name = 'delivery_frequency';
+          frequencyInput.id = 'hidden_frequency';
+          ruleForm.appendChild(frequencyInput);
+        }
+        frequencyInput.value = 'weekly';
       } else {
-        topicSection?.classList.add('hidden');
-        searchSection?.classList.remove('hidden');
+        // Switching to daily: sync topics from weekly to daily, then clear weekly
+        const checkedTopics = Array.from(weeklyTopicCheckboxes || [])
+          .filter(cb => cb.checked)
+          .map(cb => cb.value);
+
+        // Check corresponding topics in daily section
+        dailyTopicCheckboxes?.forEach(cb => {
+          cb.checked = checkedTopics.includes(cb.value);
+        });
+
+        // Uncheck all topics in weekly section (prevent duplication)
+        weeklyTopicCheckboxes?.forEach(cb => cb.checked = false);
+
+        // Show daily options, hide weekly options, show ward filter
+        dailyOptionsSection?.classList.remove('hidden');
+        weeklyOptionsSection?.classList.add('hidden');
+        wardFilterSection?.classList.remove('hidden');
+
+        // Set delivery_frequency hidden input to daily
+        let frequencyInput = document.getElementById('hidden_frequency') as HTMLInputElement;
+        if (!frequencyInput) {
+          frequencyInput = document.createElement('input');
+          frequencyInput.type = 'hidden';
+          frequencyInput.name = 'delivery_frequency';
+          frequencyInput.id = 'hidden_frequency';
+          ruleForm.appendChild(frequencyInput);
+        }
+        frequencyInput.value = 'daily';
       }
     }
 
-    ruleTypeRadios.forEach(radio => {
-      radio.addEventListener('change', toggleSections);
+    notificationTypeRadios.forEach(radio => {
+      radio.addEventListener('change', toggleNotificationTypeSections);
     });
+
+    // Initialize on page load
+    toggleNotificationTypeSections();
 
     // Open modal for new rule
     addRuleBtns.forEach(btn => {
@@ -620,16 +749,15 @@ const message = Astro.url.searchParams.get('message');
         ruleForm.reset();
         ruleIdInput.value = '';
         searchTermInput.value = '';
-        // Reset to default (search)
-        ruleTypeRadios[0].checked = true;
-        // Reset frequency to daily
-        if (frequencyRadios.length > 0) frequencyRadios[0].checked = true;
-        
+
+        // Reset to default (daily)
+        notificationTypeRadios[0].checked = true;
+
         // Reset wards UI
         wardSelectionContainer?.classList.add('hidden');
         if (toggleWardsBtn) toggleWardsBtn.textContent = 'Show Wards';
-        
-        toggleSections();
+
+        toggleNotificationTypeSections();
         modal?.classList.remove('hidden');
       });
     });
@@ -653,45 +781,73 @@ const message = Astro.url.searchParams.get('message');
         searchTermInput.value = ruleSearchTerm || '';
         isActiveInput.checked = ruleActive;
 
-        // Set frequency
-        frequencyRadios.forEach(radio => {
+        // Set notification type based on frequency
+        notificationTypeRadios.forEach(radio => {
           if (radio.value === ruleFrequency) radio.checked = true;
         });
 
-        // Set correct rule type
-        if (ruleSearchTerm) {
-          ruleTypeRadios[0].checked = true; // Search
-        } else {
-          ruleTypeRadios[1].checked = true; // Topic
-        }
-        toggleSections();
+        // Trigger toggle to show correct sections
+        toggleNotificationTypeSections();
 
-        // Check the appropriate topic checkboxes
-        const topicCheckboxes = ruleForm.querySelectorAll('input[name="topics"]') as NodeListOf<HTMLInputElement>;
-        topicCheckboxes.forEach(checkbox => {
+        // Check the appropriate topic checkboxes in the VISIBLE section only
+        const visibleSection = ruleFrequency === 'weekly' ? weeklyOptionsSection : dailyOptionsSection;
+        const topicCheckboxes = visibleSection?.querySelectorAll('input[name="topics"]') as NodeListOf<HTMLInputElement>;
+        topicCheckboxes?.forEach(checkbox => {
           checkbox.checked = ruleTopics.includes(checkbox.value);
         });
 
-        // Check the appropriate ward checkboxes
-        const wardCheckboxes = ruleForm.querySelectorAll('input[name="wards"]') as NodeListOf<HTMLInputElement>;
-        let hasSelectedWards = false;
-        wardCheckboxes.forEach(checkbox => {
-          const isChecked = ruleWards.includes(checkbox.value);
-          checkbox.checked = isChecked;
-          if (isChecked) hasSelectedWards = true;
-        });
+        // For weekly rules, don't populate ward checkboxes (they're hidden)
+        // For daily rules, populate ward checkboxes
+        if (ruleFrequency === 'daily') {
+          const wardCheckboxes = ruleForm.querySelectorAll('input[name="wards"]') as NodeListOf<HTMLInputElement>;
+          let hasSelectedWards = false;
+          wardCheckboxes.forEach(checkbox => {
+            const isChecked = ruleWards.includes(checkbox.value);
+            checkbox.checked = isChecked;
+            if (isChecked) hasSelectedWards = true;
+          });
 
-        // Expand ward section if wards are selected
-        if (hasSelectedWards) {
-          wardSelectionContainer?.classList.remove('hidden');
-          if (toggleWardsBtn) toggleWardsBtn.textContent = 'Hide Wards';
-        } else {
-          wardSelectionContainer?.classList.add('hidden');
-          if (toggleWardsBtn) toggleWardsBtn.textContent = 'Show Wards';
+          // Expand ward section if wards are selected
+          if (hasSelectedWards) {
+            wardSelectionContainer?.classList.remove('hidden');
+            if (toggleWardsBtn) toggleWardsBtn.textContent = 'Hide Wards';
+          } else {
+            wardSelectionContainer?.classList.add('hidden');
+            if (toggleWardsBtn) toggleWardsBtn.textContent = 'Show Wards';
+          }
         }
 
         modal?.classList.remove('hidden');
       });
+    });
+
+    // Form validation before submission
+    ruleForm?.addEventListener('submit', (e) => {
+      const frequencyInput = document.getElementById('hidden_frequency') as HTMLInputElement;
+      const frequency = frequencyInput?.value || 'daily';
+      const searchTerm = searchTermInput.value.trim();
+      const topicCheckboxes = ruleForm.querySelectorAll('input[name="topics"]:checked') as NodeListOf<HTMLInputElement>;
+      const hasTopics = topicCheckboxes.length > 0;
+
+      let errorMessage = '';
+
+      if (frequency === 'weekly') {
+        // Weekly rules must have at least one topic
+        if (!hasTopics) {
+          errorMessage = 'Please select at least one topic for weekly summaries.';
+        }
+      } else {
+        // Daily rules must have at least one topic OR search phrase
+        if (!hasTopics && !searchTerm) {
+          errorMessage = 'Please select at least one topic or enter a search phrase for daily digest.';
+        }
+      }
+
+      if (errorMessage) {
+        e.preventDefault();
+        alert(errorMessage);
+        return false;
+      }
     });
 
     // Close modal

--- a/frontend/src/tests/api/notifications.test.ts
+++ b/frontend/src/tests/api/notifications.test.ts
@@ -54,7 +54,7 @@ describe('Notifications API Routes', () => {
         locals: { user: { id: 'user-123' }, supabase: mockSupabase },
         formData: {
           name: 'My Search Rule',
-          rule_type: 'search',
+          delivery_frequency: 'daily',
           search_term: 'Chicago Police',
           is_active: 'on'
         }
@@ -83,7 +83,7 @@ describe('Notifications API Routes', () => {
         locals: { user: { id: 'user-123' }, supabase: mockSupabase },
         formData: {
           name: 'My Topic Rule',
-          rule_type: 'topic',
+          delivery_frequency: 'daily',
           topics: ['Politics', 'Education'],
           is_active: 'on'
         }
@@ -108,7 +108,6 @@ describe('Notifications API Routes', () => {
         locals: { user: { id: 'user-123' }, supabase: mockSupabase },
         formData: {
           name: 'Weekly Topic Rule',
-          rule_type: 'topic',
           topics: ['Politics'],
           delivery_frequency: 'weekly',
           is_active: 'on'
@@ -125,17 +124,17 @@ describe('Notifications API Routes', () => {
       }));
     });
 
-    it('forces daily frequency for search rules', async () => {
+    it('clears search term for weekly rules', async () => {
       mockSupabase.eq.mockResolvedValueOnce({ count: 2, error: null });
       mockSupabase.insert.mockResolvedValueOnce({ error: null });
 
       const context = createMockContext({
         locals: { user: { id: 'user-123' }, supabase: mockSupabase },
         formData: {
-          name: 'Search Rule',
-          rule_type: 'search',
+          name: 'Weekly Rule',
+          topics: ['Politics'],
           search_term: 'CTA',
-          delivery_frequency: 'weekly', // Try to set weekly
+          delivery_frequency: 'weekly',
           is_active: 'on'
         }
       });
@@ -144,8 +143,8 @@ describe('Notifications API Routes', () => {
 
       expect(response.status).toBe(302);
       expect(mockSupabase.insert).toHaveBeenCalledWith(expect.objectContaining({
-        search_term: 'CTA',
-        delivery_frequency: 'daily' // Should be forced to daily
+        search_term: null,
+        delivery_frequency: 'weekly'
       }));
     });
 
@@ -156,7 +155,6 @@ describe('Notifications API Routes', () => {
         locals: { user: { id: 'user-123' }, supabase: mockSupabase },
         formData: {
           name: 'Too Many Rules',
-          rule_type: 'topic',
           topics: ['Politics']
         }
       });
@@ -176,25 +174,25 @@ describe('Notifications API Routes', () => {
     it('redirects with error if name is missing', async () => {
       const context = createMockContext({
         locals: { user: { id: 'user-123' } },
-        formData: { rule_type: 'search', search_term: 'test' }
+        formData: { delivery_frequency: 'daily', search_term: 'test' }
       });
       const response = await createRulePOST(context);
       expect(response.headers.get('Location')).toContain('error=Rule name is required');
     });
 
-    it('redirects with error if search term is missing in search mode', async () => {
+    it('redirects with error if daily rule has no search term and no topics', async () => {
       const context = createMockContext({
         locals: { user: { id: 'user-123' } },
-        formData: { name: 'My Rule', rule_type: 'search' }
+        formData: { name: 'My Rule', delivery_frequency: 'daily' }
       });
       const response = await createRulePOST(context);
-      expect(response.headers.get('Location')).toContain('error=Search phrase is required');
+      expect(response.headers.get('Location')).toContain('error=Please specify at least one topic or search phrase');
     });
 
-    it('redirects with error if topics are missing in topic mode', async () => {
+    it('redirects with error if weekly rule has no topics', async () => {
       const context = createMockContext({
         locals: { user: { id: 'user-123' } },
-        formData: { name: 'My Rule', rule_type: 'topic', topics: [] }
+        formData: { name: 'My Rule', delivery_frequency: 'weekly', topics: [] }
       });
       const response = await createRulePOST(context);
       expect(response.headers.get('Location')).toContain('error=At least one topic is required');
@@ -253,7 +251,6 @@ describe('Notifications API Routes', () => {
         formData: {
           rule_id: 'rule-456',
           name: 'Updated Rule Name',
-          rule_type: 'topic',
           topics: ['Crime'],
           delivery_frequency: 'weekly',
           is_active: 'on'
@@ -281,7 +278,6 @@ describe('Notifications API Routes', () => {
         formData: {
           rule_id: 'rule-456',
           name: 'Updated Rule Name',
-          rule_type: 'topic',
           topics: ['Crime'],
           is_active: 'on'
         }

--- a/frontend/src/tests/api/notifications.test.ts
+++ b/frontend/src/tests/api/notifications.test.ts
@@ -99,6 +99,56 @@ describe('Notifications API Routes', () => {
       }));
     });
 
+    it('creates a topic rule with weekly frequency', async () => {
+      // Mock the final call in the chain to resolve with data
+      mockSupabase.eq.mockResolvedValueOnce({ count: 2, error: null });
+      mockSupabase.insert.mockResolvedValueOnce({ error: null });
+
+      const context = createMockContext({
+        locals: { user: { id: 'user-123' }, supabase: mockSupabase },
+        formData: {
+          name: 'Weekly Topic Rule',
+          rule_type: 'topic',
+          topics: ['Politics'],
+          delivery_frequency: 'weekly',
+          is_active: 'on'
+        }
+      });
+
+      const response = await createRulePOST(context);
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toContain('message=Rule created successfully');
+      expect(mockSupabase.insert).toHaveBeenCalledWith(expect.objectContaining({
+        topics: ['Politics'],
+        delivery_frequency: 'weekly'
+      }));
+    });
+
+    it('forces daily frequency for search rules', async () => {
+      mockSupabase.eq.mockResolvedValueOnce({ count: 2, error: null });
+      mockSupabase.insert.mockResolvedValueOnce({ error: null });
+
+      const context = createMockContext({
+        locals: { user: { id: 'user-123' }, supabase: mockSupabase },
+        formData: {
+          name: 'Search Rule',
+          rule_type: 'search',
+          search_term: 'CTA',
+          delivery_frequency: 'weekly', // Try to set weekly
+          is_active: 'on'
+        }
+      });
+
+      const response = await createRulePOST(context);
+
+      expect(response.status).toBe(302);
+      expect(mockSupabase.insert).toHaveBeenCalledWith(expect.objectContaining({
+        search_term: 'CTA',
+        delivery_frequency: 'daily' // Should be forced to daily
+      }));
+    });
+
     it('returns error if rule limit reached', async () => {
       mockSupabase.eq.mockResolvedValueOnce({ count: 5, error: null });
 
@@ -193,6 +243,34 @@ describe('Notifications API Routes', () => {
   });
 
   describe('POST /api/notifications/update-rule', () => {
+    it('updates a rule with frequency', async () => {
+      // First eq returns the builder, second eq resolves
+      mockSupabase.eq.mockReturnValueOnce(mockSupabase);
+      mockSupabase.eq.mockResolvedValueOnce({ error: null });
+
+      const context = createMockContext({
+        locals: { user: { id: 'user-123' }, supabase: mockSupabase },
+        formData: {
+          rule_id: 'rule-456',
+          name: 'Updated Rule Name',
+          rule_type: 'topic',
+          topics: ['Crime'],
+          delivery_frequency: 'weekly',
+          is_active: 'on'
+        }
+      });
+
+      const response = await updateRulePOST(context);
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toContain('message=Rule updated successfully');
+      expect(mockSupabase.update).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'Updated Rule Name',
+        topics: ['Crime'],
+        delivery_frequency: 'weekly'
+      }));
+    });
+
     it('updates a rule successfully', async () => {
       // First eq returns the builder, second eq resolves
       mockSupabase.eq.mockReturnValueOnce(mockSupabase);


### PR DESCRIPTION
Add support for users to opt in to a weekly email digest on any of the LLM-identified topics. This will entail an LLM extracting the most relevant items from the weeks newsletters that touched on that specific topic and aggregating them into a single report. That report will include links to the referenced newsletters. Users can subscribe to multiple topics.


<img width="1575" height="751" alt="image" src="https://github.com/user-attachments/assets/b33a1934-8f07-4071-a878-3c977ff153db" />
<img width="1894" height="933" alt="image" src="https://github.com/user-attachments/assets/8d99dbfe-02f4-433b-9325-9ed1bf0bfbe3" />

