### PR TITLE
Make newsletter IDs + ward numbers deterministic for weekly report generation

### DIFF
--- a/backend/models/weekly_report.py
+++ b/backend/models/weekly_report.py
@@ -21,7 +21,7 @@ class WeeklyTopicReport(BaseModel):
     id: str
     topic: str
     week_id: str  # Format: YYYY-WXX
-    report_summary: str = Field(..., max_length=3000)
+    report_summary: str = Field(..., max_length=5000)
     newsletter_ids: list[NewsletterID]
     key_developments: list[KeyDevelopment] | None = None
     created_at: datetime
@@ -45,6 +45,6 @@ class WeeklySynthesis(BaseModel):
     """Phase 2: Synthesize facts into narrative summary."""
 
     summary: str = Field(
-        max_length=3000,
+        max_length=5000,
         description="2-4 paragraph weekly summary of topic activity",
     )

--- a/backend/models/weekly_report.py
+++ b/backend/models/weekly_report.py
@@ -8,7 +8,7 @@ from models.types import NewsletterID
 
 
 class KeyDevelopment(BaseModel):
-    """Individual development/event extracted from newsletters."""
+    """Individual development/event extracted from newsletters (domain/storage model)."""
 
     description: str = Field(..., max_length=2000)
     newsletter_ids: list[NewsletterID] = Field(default_factory=list)
@@ -29,9 +29,14 @@ class WeeklyTopicReport(BaseModel):
 
 # LLM Response Schemas
 class FactExtraction(BaseModel):
-    """Phase 1: Extract structured facts from newsletters."""
+    """Phase 1: Extract structured facts from newsletters.
 
-    developments: list[KeyDevelopment] = Field(
+    The LLM returns only development descriptions. The owning newsletter's id
+    and ward are not LLM concerns — they are known deterministically from the
+    source and attached when building the KeyDevelopment domain objects.
+    """
+
+    developments: list[str] = Field(
         description="Key developments, decisions, or announcements"
     )
 

--- a/backend/processing/llm_client.py
+++ b/backend/processing/llm_client.py
@@ -219,6 +219,10 @@ def _add_additional_properties_false(schema: dict[str, Any]) -> dict[str, Any]:
 
     OpenAI's structured output mode requires this on all object schemas. Pydantic v2's
     model_json_schema() does not include it by default.
+
+    Note: OpenAI strict mode also requires every property to appear in 'required'.
+    We satisfy that by keeping LLM-facing models free of optional fields (Pydantic
+    then emits a complete 'required' array) rather than rewriting it here.
     """
     schema = dict(schema)
     if schema.get("type") == "object":

--- a/backend/processing/weekly_report_generator.py
+++ b/backend/processing/weekly_report_generator.py
@@ -50,6 +50,7 @@ def extract_facts_from_single_newsletter(
     )
     source_info = newsletter.get("source_name", "Unknown Source")
     newsletter_id = newsletter.get("id", "")
+    ward_number = newsletter.get("ward_number")
 
     # Build content for single newsletter
     content = f"""Source: {source_info} ({ward_info})
@@ -68,7 +69,6 @@ You are analyzing newsletters for Strong Towns Chicago, an advocacy organization
 
 For each development, provide:
 - Concrete, specific description (what happened, where, when)
-- Ward number involved (if mentioned)
 
 ONLY extract developments that are:
 ✓ Specific and factual (include locations, dates, numbers)
@@ -92,11 +92,17 @@ Newsletter:
         response = call_llm(model, prompt, FactExtraction.model_json_schema())
         data = FactExtraction.model_validate_json(response)
 
-        # Add newsletter_id to each development
-        for dev in data.developments:
-            dev.newsletter_ids = [NewsletterID(newsletter_id)]
-
-        return data.developments
+        # The LLM returns only descriptions; the newsletter's id and ward are
+        # known deterministically from the source, so attach them here.
+        wards = [str(ward_number)] if ward_number else []
+        return [
+            KeyDevelopment(
+                description=description,
+                newsletter_ids=[NewsletterID(newsletter_id)],
+                wards=wards,
+            )
+            for description in data.developments
+        ]
 
     except Exception as e:
         print(f"    ⚠ Extraction failed for newsletter {newsletter_id[:8]}: {e}")

--- a/backend/tests/unit/test_llm_client.py
+++ b/backend/tests/unit/test_llm_client.py
@@ -17,7 +17,9 @@ from processing.llm_client import (
     _extract_json,
     _get_ollama_client,
     _get_openai_client,
+    _add_additional_properties_false,
 )
+from models.weekly_report import FactExtraction
 from tests.fixtures.mock_helpers import (
     create_mock_ollama_client,
     create_mock_openai_client,
@@ -395,6 +397,75 @@ class TestCallOpenAI(unittest.TestCase):
 
         with self.assertRaises(Exception):
             _call_openai("gpt-5", "test prompt", None, 0, 2)
+
+
+class TestAddAdditionalPropertiesFalse(unittest.TestCase):
+    """Tests for _add_additional_properties_false() and OpenAI strict-mode validity."""
+
+    def _collect_objects(self, node):
+        """Yield every object-type schema dict reachable from node."""
+        if isinstance(node, dict):
+            if node.get("type") == "object" and "properties" in node:
+                yield node
+            for value in node.values():
+                yield from self._collect_objects(value)
+        elif isinstance(node, list):
+            for value in node:
+                yield from self._collect_objects(value)
+
+    def test_sets_additional_properties_false_on_all_objects(self):
+        """Every nested object gets additionalProperties: false."""
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "$defs": {
+                "Inner": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                }
+            },
+        }
+
+        result = _add_additional_properties_false(schema)
+
+        objects = list(self._collect_objects(result))
+        self.assertTrue(objects)
+        for obj in objects:
+            self.assertIs(obj["additionalProperties"], False)
+
+    def test_does_not_mutate_input_schema(self):
+        """The input schema dict is not mutated in place."""
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+        }
+
+        _add_additional_properties_false(schema)
+
+        self.assertNotIn("additionalProperties", schema)
+
+    def test_real_fact_extraction_schema_is_strict_valid(self):
+        """Regression: the schema sent to OpenAI must satisfy strict mode.
+
+        OpenAI strict mode requires every object to set additionalProperties:false
+        (added here) and to list every property in 'required' (which Pydantic emits
+        only when the model has no optional fields). FactExtraction previously nested
+        a development with optional fields, causing a 400 during weekly report
+        generation; keeping LLM-facing models free of optional fields prevents it.
+        This test guards both invariants together.
+        """
+        result = _add_additional_properties_false(FactExtraction.model_json_schema())
+
+        objects = list(self._collect_objects(result))
+        self.assertTrue(objects)
+        for obj in objects:
+            self.assertIs(obj["additionalProperties"], False)
+            self.assertEqual(
+                set(obj["required"]),
+                set(obj["properties"].keys()),
+                msg="every property must appear in required for strict mode",
+            )
 
 
 class TestClientLifecycle(unittest.TestCase):

--- a/backend/tests/unit/test_weekly_report_generator.py
+++ b/backend/tests/unit/test_weekly_report_generator.py
@@ -10,6 +10,7 @@ import io
 from unittest.mock import patch
 from processing.weekly_report_generator import (
     extract_facts_from_newsletters,
+    extract_facts_from_single_newsletter,
     synthesize_weekly_summary,
 )
 from models.weekly_report import KeyDevelopment
@@ -73,6 +74,76 @@ class TestExtractFactsFromNewsletters(unittest.TestCase):
         self.assertEqual(result[0].description, "Success")
         # All 3 were attempted despite failures
         self.assertEqual(mock_extract.call_count, 3)
+
+
+class TestExtractFactsFromSingleNewsletter(unittest.TestCase):
+    """Tests for extract_facts_from_single_newsletter() LLM extraction + mapping."""
+
+    def setUp(self):
+        """Suppress print output."""
+        self.held_output = io.StringIO()
+        sys.stdout = self.held_output
+
+    def tearDown(self):
+        """Restore stdout."""
+        sys.stdout = sys.__stdout__
+
+    @patch("processing.weekly_report_generator.call_llm")
+    def test_attaches_newsletter_id_and_ward_deterministically(self, mock_llm):
+        """The LLM returns only a description; id and ward come from the source."""
+        # The LLM response provides only description — newsletter_ids and wards
+        # are known deterministically from the source newsletter.
+        mock_llm.return_value = '{"developments": ["Approved protected bike lanes"]}'
+        newsletter = {
+            "id": "nl-42",
+            "subject": "Safety update",
+            "plain_text": "content",
+            "source_name": "Alderman 5",
+            "ward_number": "5",
+        }
+
+        result = extract_facts_from_single_newsletter(
+            "street_safety_or_traffic_calming", newsletter
+        )
+
+        self.assertEqual(len(result), 1)
+        dev = result[0]
+        self.assertIsInstance(dev, KeyDevelopment)
+        self.assertEqual(dev.description, "Approved protected bike lanes")
+        self.assertEqual(dev.wards, ["5"])  # from source ward_number, not the LLM
+        self.assertEqual(dev.newsletter_ids, ["nl-42"])
+
+    @patch("processing.weekly_report_generator.call_llm")
+    def test_citywide_source_yields_no_wards(self, mock_llm):
+        """A source without a ward number (citywide official) yields empty wards."""
+        mock_llm.return_value = '{"developments": ["Citywide budget announcement"]}'
+        newsletter = {
+            "id": "nl-7",
+            "subject": "Budget",
+            "plain_text": "content",
+            "source_name": "City Treasurer",
+            # no ward_number
+        }
+
+        result = extract_facts_from_single_newsletter("city_budget", newsletter)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].wards, [])
+
+    @patch("processing.weekly_report_generator.call_llm")
+    def test_returns_empty_list_on_llm_failure(self, mock_llm):
+        """A failed LLM call yields an empty list rather than raising."""
+        mock_llm.side_effect = Exception("LLM timeout")
+        newsletter = {
+            "id": "nl-1",
+            "subject": "S",
+            "plain_text": "C",
+            "source_name": "Src",
+        }
+
+        result = extract_facts_from_single_newsletter("city_budget", newsletter)
+
+        self.assertEqual(result, [])
 
 
 class TestSynthesizeWeeklySummary(unittest.TestCase):

--- a/backend/utils/newsletter_token_analyzer.py
+++ b/backend/utils/newsletter_token_analyzer.py
@@ -344,7 +344,7 @@ Newsletter:
 """
 
         # Typical response with 1-2 developments
-        phase1_response = '{"developments": [{"description": "Plan Commission approved 120-unit development at 1234 Main St", "newsletter_ids": [], "wards": ["42"]}]}'
+        phase1_response = '{"developments": ["Plan Commission approved 120-unit development at 1234 Main St"]}'
 
         phase1_tokens = estimate_llm_call_tokens(
             phase1_prompt,


### PR DESCRIPTION
Make newsletter IDs + ward numbers deterministic for weekly report generation. They had been optional fields the LLM could generate but this was [causing errors](https://github.com/StrongTownsChicago/chicago-newsletter-aggregator/actions/runs/27155001005/job/80155474786) + was a waste of tokens.